### PR TITLE
Fix VS Code Erroneous IntelliSense Error Highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ CMakeUserPresets.json
 .ccls-cache
 
 # VSCode
-.vscode
+.vscode/*
 .DS_Store
 Icon\r
+
+# Nano
+.*.swp
+
+# Exceptions (please work to reduce this list)
+!.vscode/c_cpp_properties.json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "name": "VS Code IntelliSense",
+            "cStandard": "gnu11",
+            "cppStandard": "gnu++11",
+            "intelliSenseMode": "${default}",
+            "configurationProvider": "ms-vscode.cmake-tools",
+            "compileCommands": [
+                "build/HOOTLTest/compile_commands.json",
+                "build/Debug/compile_commands.json",
+                "build/RelWithDebInfo/compile_commands.json",
+                "build/Release/compile_commands.json",
+                "build/MinSizeRel/compile_commands.json",
+                "compile_commands.json"
+            ],
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "mergeConfigurations": true
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
Sets up a `c_cpp_properties.json` file that points to the correct `compile_commands.json` for the given configurations:
```json
"compileCommands": [
    "build/HOOTLTest/compile_commands.json",
    "build/Debug/compile_commands.json",
    "build/RelWithDebInfo/compile_commands.json",
    "build/Release/compile_commands.json",
    "build/MinSizeRel/compile_commands.json",
    "compile_commands.json"
],
```

This means opening up a random file that is built by CMake (generally) does not result in IntelliSense syntax error highlighting that can be misleading to the dev. Note that this will not help a file that is not being built through standard CMake tools

Tested by going to HAL, CMSIS, G4BLINKY, and U5BLINKY and not seeing any IntelliSense warnings/errors.

You may have to run `cmake --configure <PRESET>` or select your preset inside of VS Code for IntelliSense to work correctly.

This should not override user/device specific configurations but YMMV please report issues.