### PR TITLE
Upload Release Artifacts as Part of GitHub Action Building

### DIFF
--- a/.github/workflows/BuildAllPresets.yml
+++ b/.github/workflows/BuildAllPresets.yml
@@ -43,3 +43,14 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           cmake --build build/${{ matrix.prefix }} |& tee -a $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload MinSizeRel Builds
+        if: matrix.prefix == 'MinSizeRel'
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-release
+          path: build/${{ matrix.prefix }}/*.elf
+          retention-days: 7
+          if-no-files-found: error
+          compression-level: 0
+          overwrite: true

--- a/.github/workflows/BuildAllPresets.yml
+++ b/.github/workflows/BuildAllPresets.yml
@@ -44,11 +44,11 @@ jobs:
           cmake --build build/${{ matrix.prefix }} |& tee -a $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
-      - name: Upload MinSizeRel Builds
-        if: matrix.prefix == 'MinSizeRel'
+      - name: Upload RelWithDebInfo Builds
+        if: matrix.prefix == 'RelWithDebInfo'
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-release
+          name: firmware-release-with-deb-info
           path: build/${{ matrix.prefix }}/*.elf
           retention-days: 7
           if-no-files-found: error


### PR DESCRIPTION
Part of a future plan to automatically upload software builds when they are ready

This PR uploads the minimum size release ELF files to the GitHub Actions window