### PR TITLE
Setup Git Attributes File For Line Endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+/build/* export-ignore


### PR DESCRIPTION
Add .gitattributes to manage line endings and export-ignore build files

* Enforced automatic line ending normalization to LF for all files by adding `* text=auto eol=lf`.
* Ensured that all files under the `/build/` directory are ignored during export operations by adding `/build/* export-ignore`.

This should help with CRLF / LF issues