### PR TITLE
Run Actions After Autoformatter If It Changes Something During Run

### DIFF
--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -2,7 +2,6 @@ name: ClangFormat
 
 on:
   pull_request:
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,15 +15,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout Branch
-        if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
-
       - name: Checkout Pull Request
-        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN}}
 
       - name: Format Files
         run: |

--- a/G4BLINKY/Core/Src/gpio.c
+++ b/G4BLINKY/Core/Src/gpio.c
@@ -41,8 +41,8 @@ void MX_GPIO_Init(void)
 
 	/* GPIO Ports Clock Enable */
 	__HAL_RCC_GPIOA_CLK_ENABLE();
-	__HAL_RCC_GPIOB_CLK_ENABLE();
-	__HAL_RCC_GPIOC_CLK_ENABLE();
+		__HAL_RCC_GPIOB_CLK_ENABLE();
+		__HAL_RCC_GPIOC_CLK_ENABLE();
 
 	/*Configure GPIO pin Output Level */
 	HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);

--- a/G4BLINKY/Core/Src/gpio.c
+++ b/G4BLINKY/Core/Src/gpio.c
@@ -41,8 +41,8 @@ void MX_GPIO_Init(void)
 
 	/* GPIO Ports Clock Enable */
 	__HAL_RCC_GPIOA_CLK_ENABLE();
-		__HAL_RCC_GPIOB_CLK_ENABLE();
-		__HAL_RCC_GPIOC_CLK_ENABLE();
+	__HAL_RCC_GPIOB_CLK_ENABLE();
+	__HAL_RCC_GPIOC_CLK_ENABLE();
 
 	/*Configure GPIO pin Output Level */
 	HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);


### PR DESCRIPTION
Resolves https://github.com/Gaucho-Racing/Firmware/pull/24#issuecomment-3315432874

Changes the auto format action to only run on pull requests and to rerun the other actions if the formatter pushes a commit.

This ensures that the tests are run on the most recent version of the pull request.