### PR TITLE
Update VSCode Settings with File Associations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-    "C_Cpp.default.intelliSenseMode": "gcc-arm"
+    "C_Cpp.default.intelliSenseMode": "gcc-arm",
+    "files.associations": {
+        "*.h": "c",
+        "*.c": "c",
+        "*.cmake": "cmake",
+        "CMakeLists.txt": "cmake",
+        "*.ld": "ld",
+        "*.s": "asm"
+    },
+    "C_Cpp.default.cStandard": "gnu11"
 }


### PR DESCRIPTION
Update VSCode settings to include file associations and specify C standard

Helps with red underline issues in some discrete cases

Replaces automatically added with the correct abstraction, supersedes edf7a49dad72c3986aa37b1d8fe715241e7da8cf