### PR TITLE
Minimize Permission Scope of GitHub Actions

### DIFF
--- a/.github/workflows/BuildAllPresets.yml
+++ b/.github/workflows/BuildAllPresets.yml
@@ -15,6 +15,8 @@ jobs:
   cmake:
     name: Configure and Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout Pull Request
         uses: actions/checkout@v4

--- a/.github/workflows/RunCTests.yml
+++ b/.github/workflows/RunCTests.yml
@@ -15,6 +15,8 @@ jobs:
   ctest:
     name: Configure, Build, and Run HOOTLTest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ValidateConfigs.yml
+++ b/.github/workflows/ValidateConfigs.yml
@@ -15,6 +15,8 @@ jobs:
   cmake:
     name: Validate Configurations
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Prevents GitHub actions in malicious forks from doing any unintended action

Resolves
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/1
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/2
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/3