### PR TITLE
Revise installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ When able, please add VS Code comptatible doc comments! These will help debuggin
 
 ## Install Tools/Dependencies
 *For Windows:*
-1. [CMake](https://cmake.org/download/)
-2. [Ninja](https://github.com/ninja-build/ninja/releases)
-3. [ARM Toolchain (arm-none-eabi)](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
-4. [OpenOCD](https://github.com/openocd-org/openocd/releases/latest)
-5. Add the executable files to `PATH` if not already done at install time
-6. Relaunch your terminal
-
-*For Windows (WinGet):*
 1. `winget install Ninja-build.Ninja Kitware.CMake Arm.GnuArmEmbeddedToolchain`
 2. [OpenOCD](https://github.com/openocd-org/openocd/releases/latest) -> Download the `.tar.gz` file, extract to directory, add the bin directory to your `PATH`
 3. Relaunch your terminal


### PR DESCRIPTION
Updated installation instructions for various platforms and corrected links.

This pull request updates the `README.md` to provide clearer and more comprehensive instructions for setting up the development environment across Windows, MacOS, and Linux/BSD. The new instructions include platform-specific installation steps, improved dependency verification, and clearer guidance on adding executables to the system `PATH`.

**Improvements to setup instructions:**

* Added explicit, platform-specific installation instructions for Windows (using WinGet), MacOS (using Homebrew), and Linux/BSD (using the appropriate package manager).
* Updated the OpenOCD download link to always use the latest release and clarified extraction and `PATH` setup steps.
* Added steps to ensure all executable files are added to the system `PATH` and instructed users to relaunch their terminal after setup.

**Dependency verification and summary:**

* Consolidated and clarified the dependency verification section, listing commands to check installation for all required tools.
* Provided a concise summary of the toolchain flow and clarified the role of each tool in the build process.