### PR TITLE
Rename validate configuration files workflow

### DIFF
--- a/.github/workflows/ValidateConfigs.yml
+++ b/.github/workflows/ValidateConfigs.yml
@@ -1,4 +1,4 @@
-name: ValidateConfigs
+name: Validate Configuration Files
 run-name: Validate Configuration Files - ${{ github.ref_name }}
 
 on:
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cmake:
-    name: Validate Configurations
+  validate:
+    name: Complete Validation
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for configuration validation. The changes focus on improving naming clarity and consolidating job names.

Workflow naming and job updates:

* Renamed the workflow from "ValidateConfigs" to "Validate Configuration Files" for better clarity. (.github/workflows/ValidateConfigs.yml)
* Changed the job name from `cmake` to `validate` and updated the display name from "Validate Configurations" to "Complete Validation" to better reflect the job's purpose. (.github/workflows/ValidateConfigs.yml)