### PR TITLE
Specify GH Action Permissions on Sum Targets

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -104,6 +104,7 @@ jobs:
     name: Complete Auto Format
     needs: [ clang, cmake, json ]
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Complete Auto Format
         run: |

--- a/.github/workflows/BuildAllPresets.yml
+++ b/.github/workflows/BuildAllPresets.yml
@@ -123,6 +123,7 @@ jobs:
     name: Complete All Presets
     needs: cmake
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Build All Presets
         run: |

--- a/.github/workflows/RunCTests.yml
+++ b/.github/workflows/RunCTests.yml
@@ -105,6 +105,7 @@ jobs:
     name: Complete HOOTL Tests
     needs: ctest
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Complete All CTest Runs
         run: |


### PR DESCRIPTION
# Resolve GH Action Permissions

## Problem and Scope
Must specify no permissions if none are required for safety

## Description
Add a zero-ed permission scope to sum jobs

## Gotchas and Limitations
Would need to change scope if doing more in that step

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
The actions still run and are required correctly

## Larger Impact
None

## Additional Context and Ticket

Resolves
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/4
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/5
- https://github.com/Gaucho-Racing/Firmware/security/code-scanning/6