### PR TITLE
Fix State Machine Diagram for GitHub Light Mode

### DIFF
--- a/Lib/GlobalShare/StateMachine.md
+++ b/Lib/GlobalShare/StateMachine.md
@@ -22,7 +22,7 @@ The state machine runs on the ECU, but it maps to an enum which may be transmitt
     'secondBkg': 'transparent',
     'tertiaryBkg': 'transparent'
   },
-  'themeCSS': '.transition { stroke: #808080; } marker path { fill: #808080; stroke: #808080; } .node rect, .node circle, .node ellipse, .node polygon, .node path { stroke: #808080; stroke-width: 0; }'
+  'themeCSS': '.transition { stroke: #808080; } marker path { fill: #808080; stroke: #808080; }'
 }}%%
 
 stateDiagram
@@ -63,10 +63,10 @@ stateDiagram
     Drive_Active : Drive Active
     Tractive_System_Discharge : Tractive System Discharge
 
-    classDef safeState fill:#4ecdc4,stroke:#ffffff,stroke-width:1px,color:#000
-    classDef hvState fill:#ff6b6b,stroke:#ffffff,stroke-width:1px,color:#fff
-    classDef transitionState fill:#ffe66d,stroke:#ffffff,stroke-width:1px,color:#000
-    classDef dischargeState fill:#ff9500,stroke:#ffffff,stroke-width:1px,color:#000
+    classDef safeState fill:#4ecdc4,stroke:#808080,stroke-width:1px,color:#000
+    classDef hvState fill:#ff6b6b,stroke:#808080,stroke-width:1px,color:#fff
+    classDef transitionState fill:#ffe66d,stroke:#808080,stroke-width:1px,color:#000
+    classDef dischargeState fill:#ff9500,stroke:#808080,stroke-width:1px,color:#000
 
     class GLV_Off,GLV_On safeState
     class Drive_Active hvState


### PR DESCRIPTION
# Light Mode State Machine Diagram

## Problem and Scope
State machine diagram in light mode has the white arrows between states disappear, making it functionally useless

## Description
Change the way the mermaid is generated by making the colors off of the default background

## Gotchas and Limitations
May be difficult for automatic screen readers, but not sure how that is supposed to work

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details

<details>
<summary>Light default</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/0c49d340-3bca-4949-9280-a36845745746" />
</details>

<details>
<summary>Light colorblind</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/87a769d9-1f55-424f-82f6-03372bdc1e24" />
</details>

<details>
<summary>Light tritanopia</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/73718998-49b5-4154-a941-da3605815bb5" />
</details>

<details>
<summary>Dark default</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/f75fe431-a542-413e-b8f7-4f9379d4a152" />
</details>

<details>
<summary>Dark colorblind</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/7a791f5b-2f66-4f9d-b841-9f61baffe3ed" />
</details>

<details>
<summary>Dark tritanopia</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/7fd9ea3c-a307-471b-9e90-8eec3ca765c3" />
</details>

<details>
<summary>Soft dark</summary>
<img width="631" height="745" alt="image" src="https://github.com/user-attachments/assets/458b43d4-9d97-47fa-bee9-aa659836d5bf" />
</details>

## Larger Impact
Readability

## Additional Context and Ticket
Resolves #99