### PR TITLE
Ensure Forked Validations Still Pass Format Checker If Possible

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
 
       - name: Format C Files
         run: |
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
 
       - name: Format JSON Files
         run: |


### PR DESCRIPTION
# Forked Format Feature

## Problem and Scope
091547b678a01a22a896d53a30ffdda47dedfd98 failed since the secret was not available on a fork on the format actions even though no formatting was needed

## Description
Add a fallback to the default GitHub token if the secret is not available

## Gotchas and Limitations
Auto format tools will fail to apply a commit if running without the secret and a format is needed

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Testing on #105

## Larger Impact
None

## Additional Context and Ticket
Helps #105 after #104 