### PR TITLE
Configure CMake Formatting Settings

### DIFF
--- a/Lib/GlobalShare/common.cmake
+++ b/Lib/GlobalShare/common.cmake
@@ -1,8 +1,20 @@
 add_library(GLOBALSHARE_LIB INTERFACE)
 
-target_include_directories(GLOBALSHARE_LIB INTERFACE ${CMAKE_CURRENT_LIST_DIR}/Inc)
+target_include_directories(
+	GLOBALSHARE_LIB
+	INTERFACE
+		${CMAKE_CURRENT_LIST_DIR}/Inc
+)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+if(
+	CMAKE_BUILD_TYPE
+		STREQUAL
+		"Debug"
+	OR
+		CMAKE_BUILD_TYPE
+			STREQUAL
+			"RelWithDebInfo"
+)
 	target_compile_definitions(GLOBALSHARE_LIB INTERFACE LOGOMATIC_ENABLED)
 	add_compile_options(
 		-u
@@ -18,12 +30,20 @@ if(CMAKE_BUILD_TYPE STREQUAL "Test")
 	target_compile_definitions(GLOBALSHARE_LIB INTERFACE LOGOMATIC_ENABLED)
 
 	add_executable(logomatic_simple)
-	target_sources(logomatic_simple PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Test/logomatic_simple_print.c)
+	target_sources(
+		logomatic_simple
+		PRIVATE
+			${CMAKE_CURRENT_LIST_DIR}/Test/logomatic_simple_print.c
+	)
 	target_link_libraries(logomatic_simple PRIVATE GLOBALSHARE_LIB)
 	add_test(logomatic_simple_test logomatic_simple)
 
 	add_executable(logomatic_float)
-	target_sources(logomatic_float PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Test/logomatic_float_print.c)
+	target_sources(
+		logomatic_float
+		PRIVATE
+			${CMAKE_CURRENT_LIST_DIR}/Test/logomatic_float_print.c
+	)
 	target_link_libraries(logomatic_float PRIVATE GLOBALSHARE_LIB)
 	add_test(logomatic_float_test logomatic_float)
 endif()

--- a/Lib/Utils/CircularBuffer/circular-buffer-lib.cmake
+++ b/Lib/Utils/CircularBuffer/circular-buffer-lib.cmake
@@ -1,42 +1,83 @@
 add_library(CircularBuffer_Lib INTERFACE)
 
-target_sources(CircularBuffer_Lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/Src/circularBuffer.c)
-target_include_directories(CircularBuffer_Lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/Inc)
+target_sources(
+	CircularBuffer_Lib
+	INTERFACE
+		${CMAKE_CURRENT_LIST_DIR}/Src/circularBuffer.c
+)
+target_include_directories(
+	CircularBuffer_Lib
+	INTERFACE
+		${CMAKE_CURRENT_LIST_DIR}/Inc
+)
 
 # link test to this library
 if(CMAKE_BUILD_TYPE STREQUAL "Test")
 	# Initialization
-	add_executable(CircularBuffer_Lib_Initialization_test ${CMAKE_CURRENT_LIST_DIR}/Test/testInitialization.c)
-	target_link_libraries(CircularBuffer_Lib_Initialization_test CircularBuffer_Lib)
-	add_test(CircularBuffer_Lib_Initialization CircularBuffer_Lib_Initialization_test)
+	add_executable(
+		CircularBuffer_Lib_Initialization_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testInitialization.c
+	)
+	target_link_libraries(
+		CircularBuffer_Lib_Initialization_test
+		CircularBuffer_Lib
+	)
+	add_test(
+		CircularBuffer_Lib_Initialization
+		CircularBuffer_Lib_Initialization_test
+	)
 
 	# Push/Pop
-	add_executable(CircularBuffer_Lib_Push_Pop_test ${CMAKE_CURRENT_LIST_DIR}/Test/testPushPop.c)
+	add_executable(
+		CircularBuffer_Lib_Push_Pop_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testPushPop.c
+	)
 	target_link_libraries(CircularBuffer_Lib_Push_Pop_test CircularBuffer_Lib)
 	add_test(CircularBuffer_Lib_Push_Pop CircularBuffer_Lib_Push_Pop_test)
 
 	# Peek
-	add_executable(CircularBuffer_Lib_Peek_test ${CMAKE_CURRENT_LIST_DIR}/Test/testPeek.c)
+	add_executable(
+		CircularBuffer_Lib_Peek_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testPeek.c
+	)
 	target_link_libraries(CircularBuffer_Lib_Peek_test CircularBuffer_Lib)
 	add_test(CircularBuffer_Lib_Peek CircularBuffer_Lib_Peek_test)
 
 	# Get Capacity
-	add_executable(CircularBuffer_Lib_Get_Capacity_test ${CMAKE_CURRENT_LIST_DIR}/Test/testGetCapacity.c)
+	add_executable(
+		CircularBuffer_Lib_Get_Capacity_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testGetCapacity.c
+	)
 	target_link_libraries(CircularBuffer_Lib_Get_Capacity_test CircularBuffer_Lib)
 	add_test(CircularBuffer_Lib_Get_Capacity CircularBuffer_Lib_Get_Capacity_test)
 
 	# Get Current Size
-	add_executable(CircularBuffer_Lib_Get_Current_Size_test ${CMAKE_CURRENT_LIST_DIR}/Test/testGetCurrentSize.c)
-	target_link_libraries(CircularBuffer_Lib_Get_Current_Size_test CircularBuffer_Lib)
-	add_test(CircularBuffer_Lib_Get_Current_Size CircularBuffer_Lib_Get_Current_Size_test)
+	add_executable(
+		CircularBuffer_Lib_Get_Current_Size_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testGetCurrentSize.c
+	)
+	target_link_libraries(
+		CircularBuffer_Lib_Get_Current_Size_test
+		CircularBuffer_Lib
+	)
+	add_test(
+		CircularBuffer_Lib_Get_Current_Size
+		CircularBuffer_Lib_Get_Current_Size_test
+	)
 
 	# If Full
-	add_executable(CircularBuffer_Lib_If_Full_test ${CMAKE_CURRENT_LIST_DIR}/Test/testIfFull.c)
+	add_executable(
+		CircularBuffer_Lib_If_Full_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testIfFull.c
+	)
 	target_link_libraries(CircularBuffer_Lib_If_Full_test CircularBuffer_Lib)
 	add_test(CircularBuffer_Lib_If_Full CircularBuffer_Lib_If_Full_test)
 
 	# Is Empty
-	add_executable(CircularBuffer_Lib_Is_Empty_test ${CMAKE_CURRENT_LIST_DIR}/Test/testIsEmpty.c)
+	add_executable(
+		CircularBuffer_Lib_Is_Empty_test
+		${CMAKE_CURRENT_LIST_DIR}/Test/testIsEmpty.c
+	)
 	target_link_libraries(CircularBuffer_Lib_Is_Empty_test CircularBuffer_Lib)
 	add_test(CircularBuffer_Lib_Is_Empty CircularBuffer_Lib_Is_Empty_test)
 endif()

--- a/Lib/cmake/HOOTL.cmake
+++ b/Lib/cmake/HOOTL.cmake
@@ -13,7 +13,11 @@ else()
 	set(_ADDRESS_SANITIZER_DEFAULT_ OFF)
 endif()
 
-option(ADDRESS_SANITIZER "Enable address sanitizer for tests, breaks Valgrind" ${_ADDRESS_SANITIZER_DEFAULT_})
+option(
+	ADDRESS_SANITIZER
+	"Enable address sanitizer for tests, breaks Valgrind"
+	${_ADDRESS_SANITIZER_DEFAULT_}
+)
 
 add_compile_options(
 	-Wall

--- a/Lib/cmake/gcc-arm-none-eabi.cmake
+++ b/Lib/cmake/gcc-arm-none-eabi.cmake
@@ -22,7 +22,10 @@ set(CMAKE_EXECUTABLE_SUFFIX_CXX ".elf")
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TARGET_FLAGS}")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -fdata-sections -ffunction-sections")
+set(
+	CMAKE_C_FLAGS
+	"${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -fdata-sections -ffunction-sections"
+)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g3")
 endif()
@@ -31,12 +34,21 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
 endif()
 
 set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -MMD -MP")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics")
+set(
+	CMAKE_CXX_FLAGS
+	"${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics"
+)
 
 set(CMAKE_C_LINK_FLAGS "${TARGET_FLAGS}")
 set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} --specs=nano.specs")
 set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--gc-sections")
-set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group")
+set(
+	CMAKE_C_LINK_FLAGS
+	"${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group"
+)
 set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--print-memory-usage")
 
-set(CMAKE_CXX_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group")
+set(
+	CMAKE_CXX_LINK_FLAGS
+	"${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group"
+)

--- a/Lib/cmake/gr-lib.cmake
+++ b/Lib/cmake/gr-lib.cmake
@@ -4,7 +4,10 @@ function(add_gr_project)
 	elseif(${ARGC} EQUAL 3)
 		set(GR_PROJECT_PATH ${ARGV2})
 	else()
-		message(FATAL_ERROR "You called add_GR_project with an unsupported number of inputs/arguments! Do better please :)")
+		message(
+			FATAL_ERROR
+			"You called add_GR_project with an unsupported number of inputs/arguments! Do better please :)"
+		)
 	endif()
 
 	set(Platform ${ARGV0})


### PR DESCRIPTION
# Expand Gersemi Configuration

## Problem and Scope
CMake auto formatter was over-expanding certain functions and not being super nice 

## Description
Add and tweak a configuration file for Gersemi (the cmake auto format engine), only real change was shrinking max line length

## Gotchas and Limitations
Should help with keeping code clean

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Whether changes look right

## Larger Impact
Every in progress PR will need to pull the change but it should be fairly automatic

## Additional Context and Ticket
Resolves #109