### PR TITLE
Update Fedora Install Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When able, please add VS Code comptatible doc comments! These will help debuggin
 * `sudo apt install cmake ninja gcc-arm-none-eabi openocd`
 * `sudo dnf install cmake ninja openocd` (Normally also `arm-none-eabi-gcc-cs arm-none-eabi-newlib` which worked on Fedora 42 but is broken on Fedora 43, use [Arm's version](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) instead for the moment)
 * `sudo pacman -S cmake ninja openocd arm-none-eabi-gcc`
-* `pkg install cmake ninja openocd arm-none-eabi-gcc`
+* `sudo pkg install cmake ninja openocd arm-none-eabi-gcc`
 * If you run into issues verify that binutils and newlib are installed for `arm-none-eabi`
 
 ### Verify that you have all these dependencies installed:


### PR DESCRIPTION
# Fedora Monorepo Tools

## Problem and Scope
Fedora 42 worked but Fedora 43 currently has a broken `arm-none-eabi-gcc` toolchain

## Description
Direct users to install from the Arm website if running Fedora 43 until a fix is out

## Gotchas and Limitations
Other OSs may have this limitation too

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
@anthony9975 Will likely test and confirm it works

## Larger Impact
Helps new users

Also made FreeBSD use `sudo` for installation 0b5a272bc13f8e22b2527d0398f28bbf2789adb8

## Additional Context and Ticket
Resolves #117 