### PR TITLE
Add CodeQL badge to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Auto Format](https://github.com/Gaucho-Racing/Firmware/actions/workflows/AutoFormat.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/AutoFormat.yml)
 [![ValidateConfigs](https://github.com/Gaucho-Racing/Firmware/actions/workflows/ValidateConfigs.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/ValidateConfigs.yml)
 [![Valgrind](https://github.com/Gaucho-Racing/Firmware/actions/workflows/MemoryCheckOnTests.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/MemoryCheckOnTests.yml)
+[![CodeQL](https://github.com/Gaucho-Racing/Firmware/actions/workflows/CodeQL.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/CodeQL.yml)
 
 Table of Contents
 * [Quickstart](#Quickstart)


### PR DESCRIPTION
# Add CodeQL Badge

## Problem and Scope
CodeQL is setup but no badge is displayed

## Description
Adds a badge to the `README.md` with the default CodeQL action status

## Gotchas and Limitations
Only shows default branch status

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Verified `REAME.md` looks right

## Larger Impact
None

## Additional Context and Ticket
Setup in #139 