### PR TITLE
Extend Holdover CAN with Bus IDs

### DIFF
--- a/Lib/FancyLayers-RENAME/GRCAN/TemporaryHoldover/Inc/GR_OLD_BUS_ID.h
+++ b/Lib/FancyLayers-RENAME/GRCAN/TemporaryHoldover/Inc/GR_OLD_BUS_ID.h
@@ -1,0 +1,18 @@
+// DO NOT CONSIDER THESE STABLE ... EXPECT URCA TO REPLACE THEM FULLY
+
+#ifndef GR_OLD_BUS_ID_H
+#define GR_OLD_BUS_ID_H
+
+/** GR CAN Bus IDs */
+typedef enum {
+	/** Testing Bus */
+	GR_OLD_BUS_TESTING = 0,
+	/** Primary Bus */
+	GR_OLD_BUS_PRIMARY = 1,
+	/** Data Bus */
+	GR_OLD_BUS_DATA = 2,
+	/** Charging Cart and ACU Bus */
+	GR_OLD_BUS_CHARGING = 3,
+} GR_OLD_BUS_ID;
+
+#endif


### PR DESCRIPTION
# Extend Holdover CAN with Bus IDs

## Problem and Scope
Previously had no way to determine bus 1 and bus 2 (and the charging cart bus), this allows for implementing things using the old approach.

## Description
Adds an enum with different options for the different busses.

## Gotchas and Limitations
Will be replaced by the URCA team

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
None

## Larger Impact
Helps #151 while URCA is in progress

## Additional Context and Ticket
See #155 and #134 