### PR TITLE
Add EMA low-pass filter module

### DIFF
--- a/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
+++ b/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
@@ -185,9 +185,9 @@ void DMA_Init(DMA_TypeDef *DMA, DMA_Channel channel, uint32_t src_address, uint3
 void ADC_UpdateAnalogValues(uint16_t **adcDataValues, volatile uint16_t *new_values, int num_signals, int window_size, uint16_t *weighted_output);
 
 typedef struct {
-    float y;
-    float alpha;
-    uint8_t initialized;
+	float y;
+	float alpha;
+	uint8_t initialized;
 } gr_lpf_ema_t;
 
 void EMA_Init(gr_lpf_ema_t *f, float alpha);

--- a/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
+++ b/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
@@ -157,34 +157,42 @@ void ADC_UpdateAnalogValues(uint16_t **adcDataValues, volatile uint16_t *new_val
 
 static float Clamp_Alpha(float a)
 {
-    if (a <= 0.0f) return 0.0001f;
-    if (a > 1.0f)  return 1.0f;
-    return a;
+	if (a <= 0.0f) {
+		return 0.0001f;
+	}
+	if (a > 1.0f) {
+		return 1.0f;
+	}
+	return a;
 }
 
 void EMA_Init(gr_lpf_ema_t *f, float alpha)
 {
-    if (!f) return;
-    f->alpha = clamp_alpha(alpha);
-    f->y = 0.0f;
-    f->initialized = 0;
+	if (!f) {
+		return;
+	}
+	f->alpha = clamp_alpha(alpha);
+	f->y = 0.0f;
+	f->initialized = 0;
 }
 
 float EMA_Update(gr_lpf_ema_t *f, float x)
 {
-    if (!f) return x;
+	if (!f) {
+		return x;
+	}
 
-    const float a = clamp_alpha(f->alpha);
+	const float a = clamp_alpha(f->alpha);
 
-    if (!f->initialized) {
-        f->y = x;
-        f->initialized = 1;
-        return f->y;
-    }
+	if (!f->initialized) {
+		f->y = x;
+		f->initialized = 1;
+		return f->y;
+	}
 
-    // EMA low-pass filter: y = y + a*(x - y)
-    f->y = f->y + a * (x - f->y);
-    return f->y;
+	// EMA low-pass filter: y = y + a*(x - y)
+	f->y = f->y + a * (x - f->y);
+	return f->y;
 }
 
 // void updateAnalogInputs(void)


### PR DESCRIPTION
# EMA Low-Pass Filter

## Problem and Scope
The existing approach for smoothing, the windowed moving average, requires a window. This is intuitive and enforces a hard cutoff for old samples. However, it needs memory, which may be less performant. I also noticed some integer division which could cause awkward truncation behavior, and the DMA is still configured as NOINCREMENT. 

Hence, I added an EMA approach to smoothing in the ADC code. 
