### PR TITLE
Reduce CI/CD Times

### DIFF
--- a/.github/workflows/ValidateConfigs.yml
+++ b/.github/workflows/ValidateConfigs.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   validate:
     name: Complete Validation
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
# Reduce GH Action Footprint

## Problem and Scope
GH Actions could be quicker

## Description
Put quicker and memory lighter actions onto `ubuntu-slim` for faster performance and lower latency for spin up

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Only a problem if HOOTL breaks

## Larger Impact
None

## Additional Context and Ticket
None