### PR TITLE
Copy `Perl::Tidy` Autoformatter Into `main` from PR #185

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
 
       - name: Format C Files
         run: |
@@ -52,15 +52,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          fetch-depth: 1
 
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
-
-      - name: Install Gersemi
-        run: pip3 install gersemi
+          pip-install: gersemi
 
       - name: Format CMake Files
         run: gersemi --in-place ${{ github.workspace }}
@@ -84,7 +83,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN || github.token }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          fetch-depth: 1
 
       - name: Format JSON Files
         run: |
@@ -100,13 +100,45 @@ jobs:
           default_author: github_actions
           message: 'Automatic Json Format: Standardized formatting automatically'
           fetch: 'false'
+  perl:
+    name: Perl
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
+          fetch-depth: 1
+
+      - name: Install Perl Tidy
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          install: 'Perl::Tidy'
+
+      - name: Format Perl Files
+        run: |
+          set -o pipefail
+          git ls-files '*.pl' '*.pm' | xargs perltidy -b -bext='/'
+
+      - name: Save Changes
+        uses: EndBug/add-and-commit@v9
+        if: github.ref_type != 'tag'
+        env:
+          HOME: ${{ github.workspace }}
+        with:
+          default_author: github_actions
+          message: 'Automatic Perl Tidy: Standardized formatting automatically'
+          fetch: 'false'
   all:
     name: Complete Auto Format
-    needs: [ clang, cmake, json ]
+    needs: [ clang, cmake, json, perl ]
     runs-on: ubuntu-slim
     permissions: {}
     steps:
       - name: Complete Auto Format
         run: |
-          echo "Auto Format has been completed for Clang, CMake, and JSON files."
+          echo "Auto Format has been completed for Clang, CMake, JSON, and Perl files."
           echo "Please refer to the individual job logs for detailed formatting information."

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,10 @@
+-l=200
+-i=4
+-tabs
+-syn
+-ole=unix
+-b
+-sfs
+-nolq
+-nola
+-bext='/'


### PR DESCRIPTION
# Copy `Perl::Tidy` Into `main`

## Problem and Scope
During some confusion #185 got changed inside of #176 which broke functionality

## Description
This adds it to `main` so that it can be pulled in and future changes can be noted explicitely

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Already tested in #185

## Larger Impact
None

## Additional Context and Ticket
Direct copy of #185 