### PR TITLE
Fix Header Guards on `Unused.h`

### DIFF
--- a/Lib/GlobalShare/Inc/Unused.h
+++ b/Lib/GlobalShare/Inc/Unused.h
@@ -1,6 +1,4 @@
-#ifndef _UNUSED_H_
-#define _UNUSED_H_
-
+#ifndef UNUSED
 /**
  * @brief Macro to mark a variable or parameter as unused.
  *
@@ -11,5 +9,4 @@
  * @param x The variable or parameter to be marked as unused.
  */
 #define UNUSED(x) (void)(x)
-
 #endif


### PR DESCRIPTION
# Prevent Redefinition of `UNUSED` Macro

## Problem and Scope
`UNUSED` is defined both in `Unused.h` and deep inside of STM32 internals, causing redefinitions

## Description
Properly verifies that `#include "Unused.h"` does not cause redefinition of `UNUSED`

## Gotchas and Limitations
None found

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Verified that adding `#include "Unused.h"` to ECU's `main.c` did not generate any warnings or related

## Larger Impact
Helps HOOTL testing with cross-compatibility

## Additional Context and Ticket
Helps testing for ECU