### PR TITLE
Rename CTests to CTest in workflow file

### DIFF
--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -167,7 +167,7 @@ jobs:
           overwrite: true
 
   ctest:
-    name: CTests
+    name: CTest
     needs: cmake
     runs-on: ${{ matrix.operatingSystem }}
     permissions:


### PR DESCRIPTION
# Correct Spelling in Workflow File

## Problem and Scope
CTest is not plural.

## Description
Changed CTests to CTest.

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Inspection

## Larger Impact
None

## Additional Context and Ticket
None