### PR TITLE
Add Output On Failure To CTest in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ HOOTLTest:
 	$(call cmake_build,$(@))
 
 sanitizer: HOOTLTest
-	ctest --test-dir build/HOOTLTest
+	ctest --test-dir build/HOOTLTest --output-on-failure
 
 clean:
 	$(rmd) build


### PR DESCRIPTION
# Verbose Makefile

## Problem and Scope
`make sanitizer` did not show the output of CTest for failed tests

## Description
Adds the correct flag so that the sanitizer has that output

## Gotchas and Limitations
Will not output on success

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Verified the flag is correct

## Larger Impact
Slightly nicer DevX

## Additional Context and Ticket
Saw in #178 