### PR TITLE
Fix `README.md` GitHub Action Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # GR Firmware
 
-[![CMake](https://github.com/Gaucho-Racing/Firmware/actions/workflows/BuildAllPresets.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/BuildAllPresets.yml)
-[![CTest](https://github.com/Gaucho-Racing/Firmware/actions/workflows/RunCTests.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/RunCTests.yml)
 [![Auto Format](https://github.com/Gaucho-Racing/Firmware/actions/workflows/AutoFormat.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/AutoFormat.yml)
-[![ValidateConfigs](https://github.com/Gaucho-Racing/Firmware/actions/workflows/ValidateConfigs.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/ValidateConfigs.yml)
-[![Valgrind](https://github.com/Gaucho-Racing/Firmware/actions/workflows/MemoryCheckOnTests.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/MemoryCheckOnTests.yml)
-[![CodeQL](https://github.com/Gaucho-Racing/Firmware/actions/workflows/CodeQL.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/CodeQL.yml)
+[![Linter](https://github.com/Gaucho-Racing/Firmware/actions/workflows/Linter.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/Linter.yml)
+[![Unit Tests](https://github.com/Gaucho-Racing/Firmware/actions/workflows/UnitTestsHOOTL.yml/badge.svg)](https://github.com/Gaucho-Racing/Firmware/actions/workflows/UnitTestsHOOTL.yml)
 
 Table of Contents
 * [Quickstart](#Quickstart)


### PR DESCRIPTION
# Fix Badges On `README.md`

## Problem and Scope
Badges on GitHub were broken in workflow unification/chaining efforts, most notably in
- #206 
- #195 

## Description
Removes outdated badges and adds the new ones

## Gotchas and Limitations
Did not edit anything else in the `README.md`, kicked the can down the road

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Looks right on render

## Larger Impact
Slight convenience

## Additional Context and Ticket
Resolves #199 