### PR TITLE
Reset GitHub Perl Tooling Versions (Unrevert)

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -117,7 +117,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1.33.0
+        uses: shogo82148/actions-setup-perl@v1
         with:
           install-modules: 'Perl::Tidy'
 

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1.33.0
+        uses: shogo82148/actions-setup-perl@v1
         with:
           install-modules: 'Perl::Critic'
 


### PR DESCRIPTION
# Restore Perl Tooling

## Problem and Scope
Perl tooling was fixed in https://github.com/shogo82148/actions-setup-perl/commit/a9867be4849b76612c4373266fe970b33bc49558 and we use an older version

## Description
Reverts #221, goes from using `@v1.33.0` to `@v1` again (see #225)

## Gotchas and Limitations
None

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Ran GitHub Actions

## Larger Impact
None

## Additional Context and Ticket
Resolves #219 
Reverts #221 