### PR TITLE
Fix Formatting Of Global Multi-Line Initializers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ IndentWidth: 8
 ColumnLimit: 200
 UseTab: Always
 BreakBeforeBraces: Linux
-BinPackLongBracedList: false
+AllowShortCompoundLiteralsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Empty
 IndentCaseLabels: true


### PR DESCRIPTION
# Fix Multiline Global Struct Instantiations

## Problem and Scope
Struts get compacted down to a single line that is difficult to parse.

## Description
Alters the auto format source document (`.clang-format`) with parameters to try and fix it

## Gotchas and Limitations
Lots of files and it takes a while to inspect

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Read through every change for readability

HOOTL testing shows no compilation changes

## Larger Impact
Code readability

## Additional Context and Ticket
Resolves #214 