### PR TITLE
Change GitHub Action Tooling To Use SHA Commit Pinning

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref }}
@@ -34,7 +34,7 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
@@ -50,14 +50,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
           pip-install: gersemi
@@ -66,7 +66,7 @@ jobs:
         run: gersemi --in-place ${{ github.workspace }}
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
@@ -82,7 +82,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
           git ls-files '*.json' | xargs -r -I{} sh -c 'jq --tab . {} > {}.tmp && mv {}.tmp {}'
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
@@ -110,14 +110,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8  # v1.37.1
         with:
           install-modules: 'Perl::Tidy'
 
@@ -127,7 +127,7 @@ jobs:
           git ls-files '*.pl' '*.pm' | xargs perltidy -b -bext='/'
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
@@ -143,14 +143,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 'stable'
 
@@ -165,7 +165,7 @@ jobs:
           git ls-files '*.s' '*.asm' | xargs -r asmfmt -w -e
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -19,12 +19,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Validate Configuration Files
-        uses: kehoecj/validate-configs-action@v4
+        uses: kehoecj/validate-configs-action@55242af1509991b2b18e2cf120eb4083a33e5c4b  # v4.0.1
 
   codeql:
     name: Analyze Code
@@ -47,17 +47,19 @@ jobs:
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 1
 
     - name: Install Arm Toolchain
       if: matrix.build_mode == 'manual'
-      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      uses: carlosperate/arm-none-eabi-gcc-action@4c88c61a77a39a33a7722d24a4e8b2c573f766c9  # v1.11.1
       with:
         release: '12.2.Rel1'
 
     - name: Setup Shared Compilation Cache
       if: matrix.build_mode == 'manual'
-      uses: actions/cache@v5
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-${{ github.workflow }}-${{ runner.os }}-${{ matrix.languages }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}-${{ github.event.pull_request.number || github.ref }}
@@ -67,14 +69,14 @@ jobs:
 
     - name: Setup Shared Compilation Cache
       if: matrix.build_mode == 'manual'
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
 
     - name: Setup Trap Cache Directory
       if: matrix.build_mode == 'manual'
       run: mkdir -p /home/runner/work/_temp/trapCaches/cpp/tarballs
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6  # v4.32.3
       with:
         languages: ${{ matrix.languages }}
         build-mode: ${{ matrix.build_mode }}
@@ -85,11 +87,11 @@ jobs:
 
     - name: Analyze CodeQL
       id: analyze
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
 
     - name: Upload Analysis Results
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
         name: codeql-${{ matrix.languages }}
         path: ${{ steps.analyze.outputs.sarif-output }}
@@ -103,12 +105,12 @@ jobs:
       checks: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8  # v1.37.1
         with:
           install-modules: 'Perl::Critic'
 
@@ -161,7 +163,7 @@ jobs:
 
       - name: Upload Annotations
         if: failure() && github.event_name == 'pull_request'
-        uses: yuzutech/annotations-action@v0.5.0
+        uses: yuzutech/annotations-action@0e061a6e3ac848299310b6429b60d67cafd4e7f8  # v0.5.0
         with:
           title: 'Perl Linter Findings'
           repo-token: ${{ github.token }}

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -29,17 +29,17 @@ jobs:
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Install Arm Toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        uses: carlosperate/arm-none-eabi-gcc-action@2ca034649a66909ef5382c90ffb5d26711d2f266  # v1.12.0
         with:
           release: '12.2.Rel1'
 
       - name: Setup Shared Compilation Cache
-        uses: actions/cache@v5
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.3
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-${{ github.workflow }}-${{ runner.os }}-${{ matrix.prefix }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}-${{ github.event.pull_request.number || github.ref }}
@@ -48,7 +48,7 @@ jobs:
             sccache-${{ github.workflow }}-${{ runner.os }}-${{ matrix.prefix }}-
 
       - name: Setup Shared Compilation Cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: CMake Configuration (Unix)
         if: matrix.operatingSystem != 'windows-latest'
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload Ubuntu RelWithDebInfo Builds
         if: matrix.prefix == 'RelWithDebInfo' && matrix.operatingSystem == 'ubuntu-latest'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: firmware-release-with-debug-info
           path: build/${{ matrix.prefix }}/*.elf
@@ -183,12 +183,12 @@ jobs:
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             fetch-depth: 1
 
       - name: Setup Shared Compilation Cache
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
             path: ${{ env.SCCACHE_DIR }}
             key: sccache-${{ github.workflow }}-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}-${{ github.event.pull_request.number || github.ref }}
@@ -197,7 +197,7 @@ jobs:
               sccache-${{ github.workflow }}-${{ runner.os }}-
 
       - name: Setup Shared Compilation Cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: CMake Configuration (Unix)
         if: matrix.operatingSystem != 'windows-latest'
@@ -311,12 +311,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Set up Valgrind
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
         with:
           packages: valgrind
 


### PR DESCRIPTION
# GitHub Actions with SHA Pinning

## Problem and Scope
GitHub Actions rely on versions of public repos, previously we used tags which can be changed which means it could introduce breaking changes

## Description
Change all tags to SHA pins with commented versions

## Gotchas and Limitations
Requires manually checking the dependabot PR

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Ran actions and they worked

## Larger Impact
Automated tooling and human review will no longer be a pointless check on GitHub Action tools

## Additional Context and Ticket
Resolves #225