### PR TITLE
GitHub Action Concurrency Failing To Cancel Irrelevant Runs

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Fix GitHub Action Group Concurrency

## Problem and Scope
Rapidly pushing individual commits queues up massive amounts of runs that are not cancelled since concurrency groups blocking this are grouped with run IDs

## Description
No longer group against run ids

## Gotchas and Limitations
May take a little time to cancel

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Re-pushed off of 1d212d8 with 99a5712 and validated that it cancelled

## Larger Impact
Pushing every commit no longer triggers up the same workload as it did before

## Additional Context and Ticket
Resolves #246