### PR TITLE
Change ECU status messages to 50 Hz

### DIFF
--- a/ECU/Application/Inc/CANutils.h
+++ b/ECU/Application/Inc/CANutils.h
@@ -8,7 +8,7 @@
 #ifndef CANUTILS_H
 #define CANUTILS_H
 
-#define ECU_STATE_DATA_SEND_INTERVAL_MS 250
+#define ECU_STATE_DATA_SEND_INTERVAL_MS 20
 void ECU_CAN_Send(GR_OLD_BUS_ID bus, GR_OLD_NODE_ID destNode, GR_OLD_MSG_ID messageID, void *data, uint32_t size);
 void SendECUStateDataOverCAN(ECU_StateData *stateData);
 


### PR DESCRIPTION
# ECU Status Message Timing

## Problem and Scope
Too fast

## Description
Set to 50 Hz

## Gotchas and Limitations
May change later

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Compiles

## Larger Impact
None

## Additional Context and Ticket
Small fix