### PR TITLE
Extend VS Code `settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,12 @@
 		"*.md": "markdown",
 		"*.pl": "perl",
 		"*.json": "json",
-		"*.yml": "yaml"
+		"*.yml": "yaml",
+		"*.html": "html",
+		"*.css": "css",
+		"*.js": "javascript",
+		"Makefile": "makefile",
+		"*.CANdo": "yaml"
 	},
 	"C_Cpp.default.cStandard": "gnu11",
 	"markdown.validate.enabled": true,


### PR DESCRIPTION
# Extend VS Code Settings

## Description
More file associations and setting active presets to always

## Gotchas and Limitations
None

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Using VS Code

## Larger Impact
Formatting and colors, may also default to selecting a preset for CMAke

## Additional Context and Ticket
None