### PR TITLE
fix implausibility logic

### DIFF
--- a/ECU/Application/Src/StateUtils.c
+++ b/ECU/Application/Src/StateUtils.c
@@ -91,8 +91,7 @@ float CalcAccPedalTravel(volatile const ECU_StateData *stateData)
 // APPS implausibility check (within 10% travel)
 bool APPS_Plausible(volatile const ECU_StateData *stateData)
 {
-	float diviation =
-	    (stateData->APPS1_Signal - THROTTLE_MIN_1 - stateData->APPS2_Signal + THROTTLE_MIN_2) * 2.0f / (THROTTLE_MAX_1 - THROTTLE_MIN_1 + THROTTLE_MAX_2 - THROTTLE_MIN_2);
+	float diviation = (stateData->APPS1_Signal - THROTTLE_MIN_1 - stateData->APPS2_Signal + THROTTLE_MIN_2) * 2.0f / (THROTTLE_MAX_1 - THROTTLE_MIN_1 + THROTTLE_MAX_2 - THROTTLE_MIN_2);
 	return diviation < 0.1 && diviation > -0.1;
 }
 


### PR DESCRIPTION
# Fix APPS Implausibility Check Logic

## Problem and Scope
Original implementation does not evaluate implausibility as a percentage to max pedal travel (and risks encountering zero-division error).

## Description
Fixes the logic

## Gotchas and Limitations


## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

## Larger Impact
Can crash ECU if not fixed

## Additional Context and Ticket
Implausibility definition: #301
Faulty implementation: #334
