### PR TITLE
Change State Machine To Be Bit Flags Instead Of Number

### DIFF
--- a/Lib/GlobalShare/Inc/StateMachine.h
+++ b/Lib/GlobalShare/Inc/StateMachine.h
@@ -17,26 +17,26 @@ enum GR_ECU_State {
 	/**
 	 * The GLV is off and not operational (not possible if ECU is running)
 	 */
-	GR_GLV_OFF = 0b00000001,
+	GR_GLV_OFF = __extension__ 0b00000001,
 	/**
 	 * The ECU is on and ready for operation.
 	 */
-	GR_GLV_ON = 0b00000010,
+	GR_GLV_ON = __extension__ 0b00000010,
 	/**
 	 * The HV precharging process has been initiated.
 	 */
-	GR_PRECHARGE_ENGAGED = 0b00000100,
+	GR_PRECHARGE_ENGAGED = __extension__ 0b00000100,
 	/**
 	 * The HV precharging process has been completed successfully.
 	 */
-	GR_PRECHARGE_COMPLETE = 0b00001000,
+	GR_PRECHARGE_COMPLETE = __extension__ 0b00001000,
 	/**
 	 * The HV system is fully operational and the drive system is active.
 	 */
-	GR_DRIVE_ACTIVE = 0b00010000,
+	GR_DRIVE_ACTIVE = __extension__ 0b00010000,
 	/**
 	 * The HV system is in the process of discharging, TS Voltage >60V.
 	 */
-	GR_TS_DISCHARGE = 0b00100000,
+	GR_TS_DISCHARGE = __extension__ 0b00100000,
 };
 #endif


### PR DESCRIPTION
# State Machine Number To Bit Flag

## Problem and Scope
CAN reading with vector prefers bit flags, and we do not have more than ~5 states so it makes life easier for TCM as well

## Description
Switch `StateMachine.h` to be bit flags instead of numbers

## Gotchas and Limitations
Needs to be validated within ECU code

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
None

## Larger Impact
ECU code needs to be reviewed

## Additional Context and Ticket
Part of the CAN LV/FW meeting