### PR TITLE
Fix `Autogen / CANfigurator` By Installing `Readonly` Module

### DIFF
--- a/.github/workflows/Autogen.yml
+++ b/.github/workflows/Autogen.yml
@@ -26,8 +26,8 @@ jobs:
         uses: shogo82148/actions-setup-perl@b6cfc127f1b0a63ac98797800f641494d80f42f8  # v1.37.1
         with:
           install-modules: |
-            'Readonly'
-            'YAML::XS'
+            Readonly
+            YAML::XS
 
       - name: Run CAN Parser
         run: |


### PR DESCRIPTION
# Fix CANfigurator Module Dependency

## Problem and Scope
GitHub Action runners fail with a missing `Readonly` module warning

## Description
Updated Perl module installation to include `Readonly`.

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Reran multiple times and cleared cache on some runs

## Larger Impact
Allows runners to work

## Additional Context and Ticket
Resolves #365 