### PR TITLE
Add URL Parsing Support For Web CANdo Viewer

### DIFF
--- a/Web/index.html
+++ b/Web/index.html
@@ -118,7 +118,7 @@
 		<script src="formSuperAdd.js?v=1"></script>
 		<script src="diffViewer.js?v=2"></script>
 		<script src="cytoscape.min.js"></script>
-		<script src="viewer.js?v=16"></script>
+		<script src="viewer.js?v=15"></script>
 		<script src="graphView.js?v=3"></script>
 		<script src="background.js?v=3"></script>
 	</body>

--- a/Web/index.html
+++ b/Web/index.html
@@ -10,8 +10,6 @@
 		<link rel="stylesheet" href="graphView.css?v=2" />
 	</head>
 	<body>
-		<div class="alert-warning">Not an official GR tool.</div>
-
 		<canvas id="bg-canvas"></canvas>
 
 		<div class="app-shell">
@@ -120,7 +118,7 @@
 		<script src="formSuperAdd.js?v=1"></script>
 		<script src="diffViewer.js?v=2"></script>
 		<script src="cytoscape.min.js"></script>
-		<script src="viewer.js?v=14"></script>
+		<script src="viewer.js?v=16"></script>
 		<script src="graphView.js?v=3"></script>
 		<script src="background.js?v=3"></script>
 	</body>

--- a/Web/viewer.js
+++ b/Web/viewer.js
@@ -20,6 +20,25 @@ window.addEventListener("DOMContentLoaded", function () {
 	const searchInput = document.getElementById("viewer-search");
 	let nodeIdMap = new Map();
 	let currentRef = "";
+	const requestedQueryKey = (() => {
+		try {
+			const params = new URLSearchParams(window.location.search);
+			if (params.has("ref")) return "ref";
+			if (params.has("branch")) return "branch";
+			return "ref";
+		} catch (_err) {
+			return "ref";
+		}
+	})();
+	const requestedRefFromUrl = (() => {
+		try {
+			const params = new URLSearchParams(window.location.search);
+			const ref = params.get("ref") || params.get("branch");
+			return ref ? ref.trim() : "";
+		} catch (_err) {
+			return "";
+		}
+	})();
 	let _allNodes = []; // persisted node→bus→messages index for search
 	let _searchDropdown = null;
 
@@ -61,6 +80,28 @@ window.addEventListener("DOMContentLoaded", function () {
 		d.className = "changed-dot";
 		d.title = "Changed";
 		container.appendChild(d);
+	}
+
+	function updateLocationState(ref) {
+		const url = new URL(window.location.href);
+		const isCustomFile = !!window.GrcanApi.isLocalMode();
+		const hasEdits =
+			!isCustomFile && !!editor && !!editor.hasUnsavedEdits && editor.hasUnsavedEdits();
+
+		if (isCustomFile) {
+			url.search = "";
+			url.hash = "custom";
+		} else {
+			if (ref) {
+				url.searchParams.set(requestedQueryKey, ref);
+			} else {
+				url.searchParams.delete("ref");
+				url.searchParams.delete("branch");
+			}
+			url.hash = hasEdits ? "edited" : "";
+		}
+
+		window.history.replaceState(null, "", url);
 	}
 
 	function messageChangeState(msgName, deviceName, busCanonical) {
@@ -1113,6 +1154,7 @@ window.addEventListener("DOMContentLoaded", function () {
 			await renderBusNode(null, text);
 		}
 		restoreSelection(snapshot || navSnapshot());
+		updateLocationState(currentRef);
 	}
 
 	if (editor) {
@@ -1179,6 +1221,7 @@ window.addEventListener("DOMContentLoaded", function () {
 		}
 		await renderHierarchy(ref);
 		currentRef = ref;
+		updateLocationState(currentRef);
 		if (typeof window.regenerateAndDrawBg === "function") {
 			window.regenerateAndDrawBg();
 		}
@@ -1210,12 +1253,21 @@ window.addEventListener("DOMContentLoaded", function () {
 			refSelect.appendChild(opt);
 		});
 
-		if (branches.includes("main")) {
-			refSelect.value = "main";
-			await renderHierarchy("main");
-			currentRef = "main";
+		const availableRefs = new Set([...branches, ...tags]);
+		const initialRef = availableRefs.has(requestedRefFromUrl)
+			? requestedRefFromUrl
+			: branches.includes("main")
+				? "main"
+				: "";
+
+		if (initialRef) {
+			refSelect.value = initialRef;
+			await renderHierarchy(initialRef);
+			currentRef = initialRef;
+			updateLocationState(currentRef);
 		} else {
 			setPlaceholder(firstList, "Select a ref");
+			updateLocationState("");
 		}
 	}
 
@@ -1235,6 +1287,7 @@ window.addEventListener("DOMContentLoaded", function () {
 				localFileInput.value = "";
 				window.GrcanApi.setLocalCandoText(null);
 				refSelect.disabled = false;
+				updateLocationState(currentRef);
 				if (currentRef) renderHierarchy(currentRef);
 			}
 		});
@@ -1246,6 +1299,7 @@ window.addEventListener("DOMContentLoaded", function () {
 				localFileInput.style.display = "none";
 				window.GrcanApi.setLocalCandoText(null);
 				refSelect.disabled = false;
+				updateLocationState(currentRef);
 				return;
 			}
 			const reader = new FileReader();
@@ -1253,6 +1307,7 @@ window.addEventListener("DOMContentLoaded", function () {
 				window.GrcanApi.setLocalCandoText(e.target.result);
 				refSelect.disabled = true;
 				renderHierarchy(currentRef || "local");
+				updateLocationState(currentRef);
 			};
 			reader.readAsText(file);
 		});
@@ -1260,6 +1315,9 @@ window.addEventListener("DOMContentLoaded", function () {
 		localFileInput.addEventListener("cancel", function () {
 			localToggle.checked = false;
 			localFileInput.style.display = "none";
+			window.GrcanApi.setLocalCandoText(null);
+			refSelect.disabled = false;
+			updateLocationState(currentRef);
 		});
 	}
 

--- a/Web/viewer.js
+++ b/Web/viewer.js
@@ -86,7 +86,10 @@ window.addEventListener("DOMContentLoaded", function () {
 		const url = new URL(window.location.href);
 		const isCustomFile = !!window.GrcanApi.isLocalMode();
 		const hasEdits =
-			!isCustomFile && !!editor && !!editor.hasUnsavedEdits && editor.hasUnsavedEdits();
+			!isCustomFile &&
+			!!editor &&
+			!!editor.hasUnsavedEdits &&
+			editor.hasUnsavedEdits();
 
 		if (isCustomFile) {
 			url.search = "";


### PR DESCRIPTION
# URL Reference Support for Web CANdo Viewer

## Problem and Scope
No longer an unofficial tool

Sharing a CANdo reference requires more steps than strictly necessary, reloading also resets the branch

## Description
Remove the unofficial tool warning/alert banner

Add support for parsing `?ref=<BRANCH>` and keep it up to date, which allows reloading, and shows `#custom` and `#edited` in the URL so that others know from a shared URL if it is a portable link or an incorrect copy

## Gotchas and Limitations
Requires testing

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Try to break it and see no errors or console warnings, needs more testing

Due to changing how URL parsing works, the [htmlpreview](https://htmlpreview.github.io/?https://github.com/Gaucho-Racing/Firmware/blob/ViewerBonuses/Web/index.html) we normally use does not work, this is expected but painful

## Larger Impact
Signal confidence in viewer

Ease of use with references and reloading the page

## Additional Context and Ticket
Hopefully no merge conflicts with #397 