### PR TITLE
Dash Panel Polling

### DIFF
--- a/DashPanel/Application/Inc/dashutils.h
+++ b/DashPanel/Application/Inc/dashutils.h
@@ -9,9 +9,23 @@
 #define NUM_LEDS 3
 #define NUM_BUTTONS 2
 
+#define GPIO_POLLING GPIOC
+#define PIN_POLLING LL_GPIO_PIN_4
+#define DEBOUNCE_TIME 10 // in ms
+typedef enum {
+    Ready,
+    DebouncePress,
+    WaitRelease,
+    DebounceRelease
+} PollingState;
+
+extern uint32_t pollingTimer;
+
 uint32_t MillisecondsSinceBoot(void);
 void NeoPixel_Init();
 void Neopixel_LEDWrite();
 void Neopixel_ButtonWrite();
+
+void PollingStateMachine();
 
 #endif

--- a/DashPanel/Application/Inc/dashutils.h
+++ b/DashPanel/Application/Inc/dashutils.h
@@ -13,10 +13,10 @@
 #define PIN_POLLING LL_GPIO_PIN_4
 #define DEBOUNCE_TIME 10 // in ms
 typedef enum {
-    Ready,
-    DebouncePress,
-    WaitRelease,
-    DebounceRelease
+	Ready,
+	DebouncePress,
+	WaitRelease,
+	DebounceRelease
 } PollingState;
 
 extern uint32_t pollingTimer;

--- a/DashPanel/Application/Src/dashutils.c
+++ b/DashPanel/Application/Src/dashutils.c
@@ -87,8 +87,6 @@ void PollingStateMachine() {
             if (LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
                 // ACTION TRIGGERED HERE
                 SetBitInByte(dashStatus.button_flags, 5, true);
-                LOGOMATIC("PC4 Set!");
-
                 pollingTimer = 0;
                 pollingState = DebouncePress;
             }

--- a/DashPanel/Application/Src/dashutils.c
+++ b/DashPanel/Application/Src/dashutils.c
@@ -12,6 +12,9 @@ static NeopixelContext NeoPixel_Button_Context;
 static Neopixel_Color LED_colors[NUM_LEDS];
 static Neopixel_Color button_colors[NUM_BUTTONS];
 
+uint32_t pollingTimer = 0;
+static PollingState pollingState = Ready;
+
 void NeoPixel_Init()
 {
 	NeopixelConfig NeoPixel_LED_Config = {.SPI_Instance = SPI2,
@@ -75,4 +78,41 @@ void Neopixel_ButtonWrite()
 
 	Neopixel_WriteAll(&NeoPixel_Button_Context, button_colors, sizeof(button_colors));
 	return;
+}
+
+void PollingStateMachine() {
+    switch (pollingState) {
+
+        case Ready:
+            if (LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
+                // ACTION TRIGGERED HERE
+                SetBitInByte(dashStatus.button_flags, 5, true);
+                LOGOMATIC("PC4 Set!");
+
+                pollingTimer = 0;
+                pollingState = DebouncePress;
+            }
+            break;
+
+        case DebouncePress:
+            if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
+                pollingState = WaitRelease;
+            }
+            break;
+
+        case WaitRelease:
+            // Wait for the pin to go Low (wire removed)
+            if (!LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
+                pollingTimer = 0;
+                pollingState = DebounceRelease;
+            }
+            break;
+
+        case DebounceRelease:
+            // Wait for the "Removal Noise" to settle before allowing a new trigger
+            if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
+                pollingState = Ready;
+            }
+            break;
+    }
 }

--- a/DashPanel/Application/Src/dashutils.c
+++ b/DashPanel/Application/Src/dashutils.c
@@ -80,37 +80,38 @@ void Neopixel_ButtonWrite()
 	return;
 }
 
-void PollingStateMachine() {
-    switch (pollingState) {
+void PollingStateMachine()
+{
+	switch (pollingState) {
 
-        case Ready:
-            if (LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
-                // ACTION TRIGGERED HERE
-                SetBitInByte(dashStatus.button_flags, 5, true);
-                pollingTimer = 0;
-                pollingState = DebouncePress;
-            }
-            break;
+		case Ready:
+			if (LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
+				// ACTION TRIGGERED HERE
+				SetBitInByte(dashStatus.button_flags, 5, true);
+				pollingTimer = 0;
+				pollingState = DebouncePress;
+			}
+			break;
 
-        case DebouncePress:
-            if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
-                pollingState = WaitRelease;
-            }
-            break;
+		case DebouncePress:
+			if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
+				pollingState = WaitRelease;
+			}
+			break;
 
-        case WaitRelease:
-            // Wait for the pin to go Low (wire removed)
-            if (!LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
-                pollingTimer = 0;
-                pollingState = DebounceRelease;
-            }
-            break;
+		case WaitRelease:
+			// Wait for the pin to go Low (wire removed)
+			if (!LL_GPIO_IsInputPinSet(GPIO_POLLING, PIN_POLLING)) {
+				pollingTimer = 0;
+				pollingState = DebounceRelease;
+			}
+			break;
 
-        case DebounceRelease:
-            // Wait for the "Removal Noise" to settle before allowing a new trigger
-            if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
-                pollingState = Ready;
-            }
-            break;
-    }
+		case DebounceRelease:
+			// Wait for the "Removal Noise" to settle before allowing a new trigger
+			if (pollingTimer >= DEBOUNCE_TIME * tick_freq) {
+				pollingState = Ready;
+			}
+			break;
+	}
 }

--- a/DashPanel/Core/Inc/main.h
+++ b/DashPanel/Core/Inc/main.h
@@ -57,6 +57,7 @@ extern "C" {
 
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
+extern uint8_t tick_freq;
 
 /* USER CODE END EC */
 
@@ -68,6 +69,7 @@ extern "C" {
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);
 void timer_inc(void);
+void pollingTimer_inc(void);
 
 /* USER CODE BEGIN EFP */
 

--- a/DashPanel/Core/Src/main.c
+++ b/DashPanel/Core/Src/main.c
@@ -63,6 +63,7 @@ LogomaticConfig logomaticConfig = {.clock_source = LOGOMATIC_PCLK1,
 				   .rx_fifo_threshold = LOGOMATIC_FIFOTHRESHOLD_1_8};
 
 volatile uint32_t timer = 0;
+uint8_t tick_freq;
 
 /* USER CODE END PV */
 
@@ -115,6 +116,8 @@ int main(void)
 
 	/* Configure the system clock */
 	SystemClock_Config();
+	tick_freq = HAL_GetTickFreq();
+
 
 	/* USER CODE BEGIN SysInit */
 	LL_mDelay(150);
@@ -128,7 +131,6 @@ int main(void)
 
 	// uint32_t previous_time = HAL_GetTick();
 	// uint32_t current_time;
-	uint8_t tick_freq = HAL_GetTickFreq();
 
 	/* USER CODE END 2 */
 
@@ -138,7 +140,7 @@ int main(void)
 	while (1) {
 		/* USER CODE END WHILE */
 
-		if (canReadyToSend || timer * tick_freq >= CAN_TIMER_DELAY) {
+		if (canReadyToSend || timer >= CAN_TIMER_DELAY * tick_freq) {
 
 			GRCAN_DASH_STATUS_MSG msg_struct;
 			msg_struct.led_bits = dashStatus.led_bits;
@@ -174,6 +176,9 @@ int main(void)
 		LL_mDelay(NEOPIXEL_DELAY);
 		Neopixel_ButtonWrite();
 		Neopixel_LEDWrite();
+
+		// Polling Button
+		PollingStateMachine();
 
 		/* USER CODE BEGIN 3 */
 	}
@@ -249,6 +254,9 @@ static void MX_GPIO_Init(void)
 
 	/* Button 4 Reset */
 	LL_GPIO_ResetOutputPin(GPIOC, LL_GPIO_PIN_4);
+
+	// Necessary for Button 4 Debouncing
+	LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_4, LL_GPIO_PULL_DOWN);
 
 	/* TS Active */
 	GPIO_InitStruct.Pin = TS_ACTIVE_BTN_Pin;
@@ -339,6 +347,11 @@ static void GPIO_Interrupt_Init(void)
 void timer_inc(void)
 {
 	timer++;
+}
+
+void pollingTimer_inc(void)
+{
+	pollingTimer++;
 }
 
 /* USER CODE END 4 */

--- a/DashPanel/Core/Src/main.c
+++ b/DashPanel/Core/Src/main.c
@@ -118,7 +118,6 @@ int main(void)
 	SystemClock_Config();
 	tick_freq = HAL_GetTickFreq();
 
-
 	/* USER CODE BEGIN SysInit */
 	LL_mDelay(150);
 	LOGOMATIC("\nBoot completed\n");

--- a/DashPanel/Core/Src/stm32g4xx_it.c
+++ b/DashPanel/Core/Src/stm32g4xx_it.c
@@ -181,6 +181,7 @@ void SysTick_Handler(void)
 {
 	/* USER CODE BEGIN SysTick_IRQn 0 */
 	timer_inc();
+	pollingTimer_inc();
 	/* USER CODE END SysTick_IRQn 0 */
 
 	/* USER CODE BEGIN SysTick_IRQn 1 */

--- a/DashPanel/README.md
+++ b/DashPanel/README.md
@@ -1,13 +1,19 @@
 # Button mappings
 
+> [!CAUTION]
+> All buttons EXCEPT Button 4 (mapped to PC4) run through a GPIO interrupt handler. Button 4 runs by polling the pin input every tick, debounced by a state machine in software. This is due to a EXTI line conflict between PA4 and PC4, which both map to EXTI line 4, but only one pin can use the line at a time. Since PA4 is mapped to the RTD button, which is crucial, we decided to "sacrifice" PC4 to the polling.
+
+
 ## butt1(TSActiveButton)
 
 TS-Active
+
 Connected to PA3
 
 ## butt2(RTDButton)
 
-RTD(Ready to Drive)
+RTD (Ready to Drive)
+
 Connected to PA4
 
 ## D1-D4(button1-button4)
@@ -17,19 +23,23 @@ All used for possible screen navigation
 ## D1(button1)
 
 Eventual Screen Navigation
+
 Connected to __
 
 ## D2(button2)
 
 Eventual Screen Navigation
+
 Connected to __
 
 ## D3(button3)
 
 Eventual Screen Navigation
+
 Connected to __
 
 ## D4(button4)
 
 Eventual Screen Navigation
+
 Connected to __

--- a/DashPanel/README.md
+++ b/DashPanel/README.md
@@ -2,6 +2,7 @@
 
 > [!CAUTION]
 > All buttons EXCEPT Button 4 (mapped to PC4) run through a GPIO interrupt handler. Button 4 runs by polling the pin input every tick, debounced by a state machine in software. This is due to a EXTI line conflict between PA4 and PC4, which both map to EXTI line 4, but only one pin can use the line at a time. Since PA4 is mapped to the RTD button, which is crucial to the car, we decided to "sacrifice" PC4 to the polling.
+> I, Bailey Say, take full responsibility if the polling messes things up.
 
 
 ## butt1(TSActiveButton)

--- a/DashPanel/README.md
+++ b/DashPanel/README.md
@@ -1,7 +1,7 @@
 # Button mappings
 
 > [!CAUTION]
-> All buttons EXCEPT Button 4 (mapped to PC4) run through a GPIO interrupt handler. Button 4 runs by polling the pin input every tick, debounced by a state machine in software. This is due to a EXTI line conflict between PA4 and PC4, which both map to EXTI line 4, but only one pin can use the line at a time. Since PA4 is mapped to the RTD button, which is crucial, we decided to "sacrifice" PC4 to the polling.
+> All buttons EXCEPT Button 4 (mapped to PC4) run through a GPIO interrupt handler. Button 4 runs by polling the pin input every tick, debounced by a state machine in software. This is due to a EXTI line conflict between PA4 and PC4, which both map to EXTI line 4, but only one pin can use the line at a time. Since PA4 is mapped to the RTD button, which is crucial to the car, we decided to "sacrifice" PC4 to the polling.
 
 
 ## butt1(TSActiveButton)


### PR DESCRIPTION
# Dash Panel Polling

## Problem and Scope
PC4 cannot be used through the GPIO interrupt handler because it conflicts with PA4. PC4 maps to the Button 4, which is necessary for Dash Screen navigation.

## Description
Since PA4 and PC4 are both configured to EXTI line 4, and only one can use the line at a time, PA4 was chosen to use the interrupt handler since it maps to the RTD button (which is crucial to the car). Thus we decided to use polling to read the value of PC4. A state machine is utilized for software debouncing.

## Gotchas and Limitations
Noise can affect the cooldown of the button since it forces the state machine to wait in certain states longer. But ideally the button used should implement hardware debouncing to smooth the signal.

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [X] Human tested

### Testing Details
PC4 is confirmed to correctly function when "pressed" every second. If PC4 is pressed more often than that, then the "cooldown" will take longer due to the extra noise, although hardware debouncing should smooth this signal out.

## Larger Impact
All the buttons should be functional now.

## Additional Context and Ticket
