### PR TITLE
fixed ECU performance data type

### DIFF
--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -3749,10 +3749,8 @@ Message ID:
       bit_start: 0
       comment:
         Represents the total number of clock cycles elapsed for 10 iterations of the main loop
-        data type: u32
-        units: Clock Cycles
-        data type: u8
-      data type: u8
+      data type: u32
+      units: Clock Cycles
 
 Custom CAN ID:
   DTI Control 1:

--- a/Autogen/CAN/Doc/GRCAN.dbc
+++ b/Autogen/CAN/Doc/GRCAN.dbc
@@ -675,7 +675,7 @@ BO_ 2147626500 ECU_ECU_Analog_Data_to_TCM: 16 ECU
  SG_ AUX_Signal : 112|16@1+ (0.0015259,0) [0|100] "%" TCM
 
 BO_ 2147626756 ECU_ECU_Performance_to_TCM: 4 ECU
- SG_ Elapsed_Cycles : 0|8@1+ (1,0) [0|0] "" TCM
+ SG_ Elapsed_Cycles : 0|32@1+ (1,0) [0|0] "Clock Cycles" TCM
 
 BO_ 2147615264 ECU_Ping_to_SAMM_Mag_1: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4,294,967,296] "ms" SAMM_Mag_1

--- a/Autogen/CAN/Inc/GRCAN_MSG_DATA.h
+++ b/Autogen/CAN/Inc/GRCAN_MSG_DATA.h
@@ -474,11 +474,8 @@ typedef struct {
 
 /** ECU Performance */
 typedef struct {
-	/** Represents the total number of clock cycles elapsed for 10 iterations of the main loop
-data type: u32
-units: Clock Cycles
-data type: u8 (Byte 0) */
-	uint8_t elapsed_cycles;
+	/** Represents the total number of clock cycles elapsed for 10 iterations of the main loop (Byte 0) */
+	uint32_t elapsed_cycles;
 } GRCAN_ECU_PERFORMANCE_MSG;
 
 #endif


### PR DESCRIPTION
# Fix ECU performance data type

## Problem and Scope
ECU performance was uint8 instead of uint32

## Description
This would break ECU code silently(no compile errors, but wrong type). 

## Gotchas and Limitations

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Looked at StructParser output

## Larger Impact
Bugfix

## Additional Context and Ticket
Related to #418 
Resolves #417 