### PR TITLE
Explore Compact Enums

### DIFF
--- a/Lib/cmake/HOOTL.cmake
+++ b/Lib/cmake/HOOTL.cmake
@@ -31,14 +31,10 @@ add_compile_options(
 	-g
 )
 
-if(APPLE)	# MacOS has a different syntax for linker fatal warnings
-	add_link_options(
-		-Wl,-fatal_warnings
-	)
+if(APPLE) # MacOS has a different syntax for linker fatal warnings
+	add_link_options(-Wl,-fatal_warnings)
 else()
-	add_link_options(
-		-Wl,--fatal-warnings
-	)
+	add_link_options(-Wl,--fatal-warnings)
 endif()
 
 if(ADDRESS_SANITIZER)

--- a/Lib/cmake/HOOTL.cmake
+++ b/Lib/cmake/HOOTL.cmake
@@ -31,7 +31,15 @@ add_compile_options(
 	-g
 )
 
-add_link_options(-Wl,--fatal-warnings)
+if(APPLE)	# MacOS has a different syntax for linker fatal warnings
+	add_link_options(
+		-Wl,-fatal_warnings
+	)
+else()
+	add_link_options(
+		-Wl,--fatal-warnings
+	)
+endif()
 
 if(ADDRESS_SANITIZER)
 	message(STATUS "Address sanitizer enabled for tests")

--- a/Lib/cmake/HOOTL.cmake
+++ b/Lib/cmake/HOOTL.cmake
@@ -17,11 +17,22 @@ option(
 )
 
 add_compile_options(
+	-fshort-enums
+	-fdata-sections
+	-ffunction-sections
+	-fstack-usage
+	-fno-lto
 	-Wall
 	-Wextra
 	-Werror
-	-pedantic
+	-Wpedantic
+	-Wvla
+	-Wdouble-promotion
 	-g
+)
+
+add_link_options(
+	-Wl,--fatal-warnings
 )
 
 if(ADDRESS_SANITIZER)

--- a/Lib/cmake/HOOTL.cmake
+++ b/Lib/cmake/HOOTL.cmake
@@ -31,9 +31,7 @@ add_compile_options(
 	-g
 )
 
-add_link_options(
-	-Wl,--fatal-warnings
-)
+add_link_options(-Wl,--fatal-warnings)
 
 if(ADDRESS_SANITIZER)
 	message(STATUS "Address sanitizer enabled for tests")

--- a/Lib/cmake/gcc-arm-none-eabi.cmake
+++ b/Lib/cmake/gcc-arm-none-eabi.cmake
@@ -24,7 +24,7 @@ set(
 )
 set(
 	CMAKE_C_FLAGS
-	"${TARGET_FLAGS} -Wall -Wextra -Wpedantic -Wvla -Wdouble-promotion -fdata-sections -ffunction-sections -fstack-usage"
+	"${TARGET_FLAGS} -Wall -Wextra -Wpedantic -Wvla -Wdouble-promotion -fshort-enums -fdata-sections -ffunction-sections -fstack-usage"
 )
 set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -MMD -MP")
 


### PR DESCRIPTION
# Compact Enums

## Problem and Scope
Enums default to `int` but that is too many bytes

## Description
Make enums packed by default

## Gotchas and Limitations
Changes internal ABI

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Assembly and data storage looks good

## Larger Impact
Ensures sizes are correct

## Additional Context and Ticket
Resolves #420