### PR TITLE
Add Missing `AnalogCalibration` Task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,15 @@
 			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target TireTemp"
 		},
 		{
+			"label": "CMake: configure and build AnalogCalibration",
+			"type": "shell",
+			"dependsOrder": "sequence",
+			"dependsOn": [
+				"CMake: configure"
+			],
+			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target AnalogCalibration"
+		},
+		{
 			"label": "CMake: configure and build G4ECHO",
 			"type": "shell",
 			"dependsOrder": "sequence",


### PR DESCRIPTION
# Add Missing `AnalogCalibration` Task

## Problem and Scope
Running the AnalogCalibration target throws a message about not having the CMake task set up for it

## Description
Set up the CMake test for it

## Gotchas and Limitations
None

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Works as expected

## Larger Impact
None

## Additional Context and Ticket
Found during LV tests