### PR TITLE
Migrate SPI Preprocessor Defines To Typesafe Enums

### DIFF
--- a/Lib/FancyLayers-RENAME/SPI/Inc/spi.h
+++ b/Lib/FancyLayers-RENAME/SPI/Inc/spi.h
@@ -11,6 +11,63 @@
 #define GR_SPI_UNKNOWN_CLOCK 0
 #define GR_SPI_BUFFER_BYTE_CAPACITY 256
 #define GR_SPI_MAX_MSG_BYTE_SIZE 64
+#define GR_SPI_INVALID_TX_SIZE 65535 // max message size is 2^16 bytes
+
+/**
+ * @brief Error status codes for SPI transactions and initialization
+ *
+ * @note Negative values indicate an error, and 0 indicates no error. The specific negative value can be used to identify the type of error that occurred.
+ */
+typedef enum {
+	/** No error */
+	GR_SPI_ERR_NONE = 0,
+	/** Frame format error */
+	GR_SPI_ERR_FRE = -1,
+	/** Overrun error */
+	GR_SPI_ERR_OVR = -2,
+	/** Fault mode error */
+	GR_SPI_ERR_MODF = -3,
+	/** CRC error */
+	GR_SPI_ERR_CRCERR = -4,
+	/** Rx buffer full */
+	GR_SPI_ERR_RXFULL = -5,
+	/** Bad NVIC initialization */
+	GR_SPI_ERR_BAD_INIT_NVIC = -6,
+	/** Bad RX buffer initialization */
+	GR_SPI_ERR_BAD_INIT_RXBUF = -7,
+	/** Bad TX buffer initialization */
+	GR_SPI_ERR_BAD_INIT_TXBUF = -8,
+	/** Bad SPIx peripheral in pin config */
+	GR_SPI_ERR_BAD_SPIX = -9,
+	/** Bad SPI address */
+	GR_SPI_ERR_BAD_ADD = -10,
+	/** Full transmit buffer */
+	GR_SPI_ERR_FULL_TRANSMIT = -11,
+	/** Bad arguments */
+	GR_SPI_ERR_BAD_ARGS = -12
+} GR_SPI_ERR;
+
+/**
+ * @brief SPI transfer sizes
+ *
+ * @note The value of the enum corresponds to the number of bits in the transfer size, but that should not be relied upon
+ */
+typedef enum {
+	/** 8-bit transfer size */
+	GR_SPI_TRANSFER_SIZE_8 = 8,
+	/** 16-bit transfer size */
+	GR_SPI_TRANSFER_SIZE_16 = 16
+} GR_SPI_TransferSize;
+
+/**
+ * @brief SPI message status codes
+ */
+typedef enum {
+	/** No ongoing message transaction */
+	GR_SPI_MSG_IDLE = 0,
+	/** Ongoing message transaction */
+	GR_SPI_MSG_IN_PROGRESS = 1,
+} GR_SPI_MsgStatus;
 
 // Generic type
 typedef struct {
@@ -42,12 +99,12 @@ typedef struct GR_SPI_Handler_struct {
 	GR_MsgBuffer *rx_buffer;
 	GR_MsgBuffer *tx_buffer;
 	// Tx-Rx parameters
-	uint8_t transfer_size;
+	GR_SPI_TransferSize transfer_size;
 	// Tx-Rx current messages
 	GR_SPI_Message current_msg;
 	volatile uint16_t current_tx_msg_index, current_rx_msg_index;
-	volatile uint8_t msg_status;
-	volatile int8_t error_status;
+	volatile GR_SPI_MsgStatus msg_status;
+	volatile GR_SPI_ERR error_status;
 } GR_SPI_Handler;
 
 // ============================= handle Functions =============================
@@ -132,7 +189,7 @@ uint32_t GR_SPI_Get_RxMsgSize(GR_SPI_Handler *handle);
  * @param handle
  * @return 0 if there is no error and -ERROR_VAL otherwise
  */
-uint8_t GR_SPI_Get_ErrorStatus(GR_SPI_Handler *handle);
+GR_SPI_ERR GR_SPI_Get_ErrorStatus(GR_SPI_Handler *handle);
 
 // ============================= Helper Functions =============================
 

--- a/Lib/FancyLayers-RENAME/SPI/Src/spi.c
+++ b/Lib/FancyLayers-RENAME/SPI/Src/spi.c
@@ -6,29 +6,6 @@
 
 #include "msgBuffer.h"
 
-// Transfer sizes
-#define GR_SPI_TRANSFER_SIZE_8 8
-#define GR_SPI_TRANSFER_SIZE_16 16
-
-// Current message status codes
-#define GR_SPI_MSG_IN_PROGRESS 1
-#define GR_SPI_MSG_IDLE 0
-#define GR_SPI_INVALID_TX_SIZE 65535 // max message size is 2^16 bytes
-
-#define GR_SPI_ERR_NONE 0
-#define GR_SPI_ERR_FRE -1
-#define GR_SPI_ERR_OVR -2
-#define GR_SPI_ERR_MODF -3
-#define GR_SPI_ERR_CRCERR -4
-#define GR_SPI_ERR_RXFULL -5
-#define GR_SPI_ERR_BAD_INIT_NVIC -6
-#define GR_SPI_ERR_BAD_INIT_RXBUF -7
-#define GR_SPI_ERR_BAD_INIT_TXBUF -8
-#define GR_SPI_ERR_BAD_SPIX -9
-#define GR_SPI_ERR_BAD_ADD -10
-#define GR_SPI_ERR_FULL_TRANSMIT -11
-#define GR_SPI_ERR_BAD_ARGS -12
-
 static GR_SPI_Handler *GR_SPI_HANDLER_LUT[3]; // Stores pointer to the handle structs for SPI1
 					      // (0), SPI2 (1), & SPI3 (2)
 
@@ -478,7 +455,7 @@ uint32_t GR_SPI_Get_RxMsgSize(GR_SPI_Handler *handle)
 	return GR_MsgBuffer_PeekMsgSize(handle->rx_buffer);
 }
 
-uint8_t GR_SPI_Get_ErrorStatus(GR_SPI_Handler *handle)
+GR_SPI_ERR GR_SPI_Get_ErrorStatus(GR_SPI_Handler *handle)
 {
 	if (!handle) {
 		return GR_SPI_ERR_BAD_ARGS;


### PR DESCRIPTION
# SPI Typesafe Enums

## Problem and Scope
Currently uses lots of `#define` values which are only in the source file and not accessible via the header file for returned values

## Description
Migrate errors, transfer sizes, message status to typedef enums in the header file

## Gotchas and Limitations
Struct size now dependent on `-fshort-enums`

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Compilation

## Larger Impact
Numbers kept the same

## Additional Context and Ticket
Resolves #419