### PR TITLE
Add Casey as a Codeowner For ECU

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-# All files require code owner approval from the firmware lead
-
-## Previous firmware leads are not marked as Code Owners to not get notifications / called on for every PR, but they will have admin on GitHub and can merge PRs without approval
-
 * @dchansen06
+
+# Out of band blanket approval permissions
+ECU/ @kzwicker


### PR DESCRIPTION
# Casey as Codeowner

## Problem and Scope
Active LV test development is complicated

## Description
Per his request, allows him to merge into `main` as he sees fit for the ECU

## Gotchas and Limitations
Not sure if this actually gives permissions or not

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
None, not until `main`

## Larger Impact
Give Casey power

## Additional Context and Ticket
By request