### PR TITLE
Migrate `validate-configs-action` to Boeing's Version

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 1
 
       - name: Validate Configuration Files
-        uses: kehoecj/validate-configs-action@55242af1509991b2b18e2cf120eb4083a33e5c4b  # v4.0.1
+        uses: Boeing/validate-configs-action@a31830f9bec7d3ec001cfab7951a966d08180a72  # v2.0.0
 
   perllinter:
     name: Perl Linter


### PR DESCRIPTION
# Migrate To Updated `validate-configs-action`

## Problem and Scope
[`kehoecj/validate-configs-action`](https://github.com/kehoecj/validate-configs-action) has been marked as an archive in favor of [`Boeing/validate-configs-action`](https://github.com/Boeing/validate-configs-action)

## Description
Migrate to Boeings version

## Gotchas and Limitations
Same author just under new management

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
HOOTL lists checked files and it does not change the list

## Larger Impact
None

## Additional Context and Ticket
Seen while looking at [stargazers](https://github.com/Gaucho-Racing/Firmware/stargazers).

[`kehoecj`](https://github.com/kehoecj) if you see this, thanks for making the tool!