### PR TITLE
Add Security Markdown File

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security
+
+Please prefer GitHub Issues, but if the concern is sensitive in nature please use the private vulnerability reporting mechanism built into GitHub. In either scenario please also ping the person in charge of firmware in the Discord.
+
+## Firmware
+For concerns related to firmware behavior, safety, or vulnerabilities, please create a new issue as the primary reporting method and include reproduction steps, logs, and affected components. Then please ping your team lead in the Discord to escalate the issue to the appropriate party.
+
+If this is during competition please ping multiple people in order to ensure the concern propogates in a timely manner.
+
+## GitHub Pages
+For concerns related to the GitHub repository or its associated GitHub Pages website, please create a new issue as the primary reporting method and include as much detail as possible.
+
+If the concern is sensitive in nature please ping either your team lead or the person in charge of the firmware in the Discord to escalate the issue to the appropriate party.


### PR DESCRIPTION
# Security Markdown

## Problem and Scope
Some recruiters like to see proper support for [Community Standards](https://github.com/Gaucho-Racing/Firmware/community)

## Description
Add security markdown file for compliance with standards

## Gotchas and Limitations
None

## Testing

- [ ] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Renders right

## Larger Impact
None

## Additional Context and Ticket
Helps our rankings and such