### PR TITLE
Fix DBC Identifier Bit Shifting

### DIFF
--- a/Autogen/CAN/Doc/GRCAN_Charger.dbc
+++ b/Autogen/CAN/Doc/GRCAN_Charger.dbc
@@ -11,14 +11,14 @@ BO_ 2550588916 BCU_Charger_Control_to_Charger: 5 BCU
  SG_ Set_Current : 16|1@1+ (1,0) [0|0] "" Charger
  SG_ Charge_Enable : 17|1@1+ (1,0) [0|0] "" Charger
 
-BO_ 2147682050 BCU_BCU_Status_1_to_CCU: 8 BCU
+BO_ 2150631170 BCU_BCU_Status_1_to_CCU: 8 BCU
  SG_ Accumulator_Voltage : 0|16@1+ (0.01,0) [0|655.35] "Volts" CCU
  SG_ TS_Voltage : 16|16@1+ (0.01,0) [0|655.35] "Volts" CCU
  SG_ Accumulator_Current : 32|16@1- (0.01,0) [-327.68|327.67] "Amps" CCU
  SG_ Accumulator_SOC : 48|8@1+ (0.392157,0) [0|100] "%" CCU
  SG_ GLV_SOC : 56|8@1+ (0.392157,0) [0|100] "%" CCU
 
-BO_ 2147682306 BCU_BCU_Status_2_to_CCU: 7 BCU
+BO_ 2150631426 BCU_BCU_Status_2_to_CCU: 7 BCU
  SG_ _20v_Voltage : 0|8@1+ (1,0) [0|0] "" CCU
  SG_ _12v_Voltage : 8|8@1+ (1,0) [0|0] "" CCU
  SG_ SDC_Voltage : 16|8@1+ (1,0) [0|0] "" CCU
@@ -27,7 +27,7 @@ BO_ 2147682306 BCU_BCU_Status_2_to_CCU: 7 BCU
  SG_ status_flags : 40|1@1+ (1,0) [0|0] "" CCU
  SG_ precharge_latch_flags : 48|1@1+ (1,0) [0|0] "" CCU
 
-BO_ 2147682562 BCU_BCU_Status_3_to_CCU: 8 BCU
+BO_ 2150631682 BCU_BCU_Status_3_to_CCU: 8 BCU
  SG_ HV_Input_Voltage : 0|16@1+ (0.01,0) [0|655.35] "Volts" CCU
  SG_ HV_Output_Voltage : 16|16@1+ (0.01,0) [0|655.35] "Volts" CCU
  SG_ HV_Input_Current : 32|16@1+ (0.001,0) [0|65.535] "Amps" CCU
@@ -42,7 +42,7 @@ BO_ 2566869221 Charger_Charger_Data_to_BCU: 8 Charger
  SG_ Connection_Error : 20|1@1+ (1,0) [0|0] "" BCU
  SG_ Communication_State : 21|1@1+ (1,0) [0|0] "" BCU
 
-BO_ 2147549708 Debugger_Ping_to_Charging_SDC: 4 Debugger
+BO_ 2148532748 Debugger_Ping_to_Charging_SDC: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Charging_SDC
 
 BO_ 269 Energy_Meter_EM_Measurement_to_BCU: 8 Energy_Meter
@@ -80,35 +80,35 @@ BO_ 2566849012 IMD_IMD_general_to_BCU: 8 IMD
  SG_ Status : 32|16@1+ (1,0) [0|0] "" BCU
  SG_ Activity : 48|8@1+ (1,0) [0|0] "" BCU
 
-BO_ 2147617283 CCU_BCU_Precharge_to_BCU: 1 CCU
+BO_ 2149583363 CCU_BCU_Precharge_to_BCU: 1 CCU
  SG_ Set_TS_Active : 0|1@1+ (1,0) [0|0] "Bool" BCU
 
-BO_ 2147614723 CCU_Debug_2_0_to_BCU: 8 CCU
+BO_ 2149580803 CCU_Debug_2_0_to_BCU: 8 CCU
  SG_ Debug : 0|64@1- (1,0) [0|0] "" BCU
 
 CM_ SG_ 2550588916 Charge_Enable "1: Start Charging 0: Stop Charging";
-CM_ SG_ 2147682050 Accumulator_Voltage "All cell voltages added up";
-CM_ SG_ 2147682050 TS_Voltage "Output terminal voltage of accumulator";
-CM_ SG_ 2147682050 Accumulator_Current "Current output of accumulator";
-CM_ SG_ 2147682050 Accumulator_SOC "Accumulator state of charge (Based on lowest cell)";
-CM_ SG_ 2147682050 GLV_SOC "GLV state of charge";
-CM_ SG_ 2147682306 _20v_Voltage "20v GLV voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 _12v_Voltage "12v supply voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 SDC_Voltage "Voltage before BCU Latch data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 Min_Cell_Voltage "Lowest cell voltage in accumulator data type: u8 units: Volts scaled min: 2 scaled max: 4.55 map equation: \"0.01x+2\"";
-CM_ SG_ 2147682306 Max_Cell_Temp "Hottest cell in accumulator data type: u8 units: Celsius scaled min: 0 scaled max: 63.75 map equation: \"0.25x\"";
-CM_ SG_ 2147682306 status_flags "[Byte 5 / Bits 40-47] 40: Over Temp (>60C) 41: Over Voltage (>4.2V/cell) 42: Under Volt (<2.5V/cell) 43: Over Current (Discharge) 44: Under Current (Charge) 45: 20V GLV Warning 46: 12V Supply Warning 47: SDC Warning";
-CM_ SG_ 2147682306 precharge_latch_flags "[Byte 6 / Bits 48-55] 48: Precharge Timeout 49: IR- / Precharge State (0:Open, 1:Closed) 50: IR+ State (0:Open, 1:Closed) 51: Software Latch (0:Open, 1:Closed) 52-55: Reserved";
-CM_ SG_ 2147682562 HV_Input_Voltage "600v input voltage";
-CM_ SG_ 2147682562 HV_Output_Voltage "20v output voltage";
-CM_ SG_ 2147682562 HV_Input_Current "600v input current";
-CM_ SG_ 2147682562 HV_Output_Current "20v output current";
+CM_ SG_ 2150631170 Accumulator_Voltage "All cell voltages added up";
+CM_ SG_ 2150631170 TS_Voltage "Output terminal voltage of accumulator";
+CM_ SG_ 2150631170 Accumulator_Current "Current output of accumulator";
+CM_ SG_ 2150631170 Accumulator_SOC "Accumulator state of charge (Based on lowest cell)";
+CM_ SG_ 2150631170 GLV_SOC "GLV state of charge";
+CM_ SG_ 2150631426 _20v_Voltage "20v GLV voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 _12v_Voltage "12v supply voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 SDC_Voltage "Voltage before BCU Latch data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 Min_Cell_Voltage "Lowest cell voltage in accumulator data type: u8 units: Volts scaled min: 2 scaled max: 4.55 map equation: \"0.01x+2\"";
+CM_ SG_ 2150631426 Max_Cell_Temp "Hottest cell in accumulator data type: u8 units: Celsius scaled min: 0 scaled max: 63.75 map equation: \"0.25x\"";
+CM_ SG_ 2150631426 status_flags "[Byte 5 / Bits 40-47] 40: Over Temp (>60C) 41: Over Voltage (>4.2V/cell) 42: Under Volt (<2.5V/cell) 43: Over Current (Discharge) 44: Under Current (Charge) 45: 20V GLV Warning 46: 12V Supply Warning 47: SDC Warning";
+CM_ SG_ 2150631426 precharge_latch_flags "[Byte 6 / Bits 48-55] 48: Precharge Timeout 49: IR- / Precharge State (0:Open, 1:Closed) 50: IR+ State (0:Open, 1:Closed) 51: Software Latch (0:Open, 1:Closed) 52-55: Reserved";
+CM_ SG_ 2150631682 HV_Input_Voltage "600v input voltage";
+CM_ SG_ 2150631682 HV_Output_Voltage "20v output voltage";
+CM_ SG_ 2150631682 HV_Input_Current "600v input current";
+CM_ SG_ 2150631682 HV_Output_Current "20v output current";
 CM_ SG_ 2566869221 Hardware_Failure "Bit 0: Hardware Failure: 0-Normal, 1-Error";
 CM_ SG_ 2566869221 OverTemp "Bit 1: OverTemp: 0-Normal, 1-Error";
 CM_ SG_ 2566869221 Input_Voltage_Error "Bit 2: Input Voltage: 0-Normal, 1-Wrong input voltage";
 CM_ SG_ 2566869221 Connection_Error "Bit 3: Starting State: 0-Correct, 1-Wrong polarity or NC";
 CM_ SG_ 2566869221 Communication_State "Bit 4: Communication State: 0-Normal, 1-Timeout";
-CM_ SG_ 2147549708 Timestamp "Time in millis";
+CM_ SG_ 2148532748 Timestamp "Time in millis";
 CM_ SG_ 269 Current "TS Current";
 CM_ SG_ 269 Voltage "TS Voltage";
 CM_ SG_ 781 Team_Signal_1 "Frick if I know";
@@ -124,5 +124,5 @@ CM_ SG_ 1549 Min_Temp "Min temp of all sensors";
 CM_ SG_ 1549 Max_Temp "Max temp of all sensors";
 CM_ SG_ 1549 Temp_5n "[0,5,10,15,20,25,30] based on n above";
 CM_ SG_ 2566849012 Status "Bit 0: true = Device error active Bit 1: true = HV_pos connection failure Bit 2: true = HV_neg connection failure Bit 3: true = Earth connection failure Bit 4: true = Iso Alarm (iso value below threshold error) Bit 5: true = Iso Warning (iso value below threshold warning) Bit 6: true = Iso Outdated (value \"Time elapsed since lst measurement\" > = \"measurement timeout\") Bit 7: true = Unbalance Alarm (unbalance value below threshold) Bit 8: true = Undervoltage Alarm Bit 9: true = Unsafe to Start Bit 10: true = Earthlift open";
-CM_ SG_ 2147617283 Set_TS_Active "0: shutdown, 1: go TS Active/Precharge";
-CM_ SG_ 2147614723 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2149583363 Set_TS_Active "0: shutdown, 1: go TS Active/Precharge";
+CM_ SG_ 2149580803 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";

--- a/Autogen/CAN/Doc/GRCAN_Data.dbc
+++ b/Autogen/CAN/Doc/GRCAN_Data.dbc
@@ -6,16 +6,16 @@ BS_:
 
 BU_: BCU DGPS Debugger ECU SAMM_Mag_1 SAMM_Mag_2 SAMM_ToF_1 SAMM_ToF_2 TCM TireTemp_FL TireTemp_FR TireTemp_RL TireTemp_RR
 
-BO_ 2147680513 BCU_Debug_FD_to_Debugger: 64 BCU
+BO_ 2150629633 BCU_Debug_FD_to_Debugger: 64 BCU
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2147680769 BCU_Ping_to_Debugger: 4 BCU
+BO_ 2150629889 BCU_Ping_to_Debugger: 4 BCU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147680770 BCU_Ping_to_ECU: 4 BCU
+BO_ 2150629890 BCU_Ping_to_ECU: 4 BCU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2147683586 BCU_BCU_Cell_Data_1_to_ECU: 64 BCU
+BO_ 2150632706 BCU_BCU_Cell_Data_1_to_ECU: 64 BCU
  SG_ Cell_0_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_0_Temp : 8|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
  SG_ Cell_1_Voltage : 16|8@1+ (0.01,2) [2|4.55] "Volts" ECU
@@ -81,7 +81,7 @@ BO_ 2147683586 BCU_BCU_Cell_Data_1_to_ECU: 64 BCU
  SG_ Cell_31_Voltage : 496|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_31_Temp : 504|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
 
-BO_ 2147683842 BCU_BCU_Cell_Data_2_to_ECU: 64 BCU
+BO_ 2150632962 BCU_BCU_Cell_Data_2_to_ECU: 64 BCU
  SG_ Cell_32_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_32_Temp : 8|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
  SG_ Cell_33_Voltage : 16|8@1+ (0.01,2) [2|4.55] "Volts" ECU
@@ -147,7 +147,7 @@ BO_ 2147683842 BCU_BCU_Cell_Data_2_to_ECU: 64 BCU
  SG_ Cell_63_Voltage : 496|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_63_Temp : 504|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
 
-BO_ 2147684098 BCU_BCU_Cell_Data_3_to_ECU: 64 BCU
+BO_ 2150633218 BCU_BCU_Cell_Data_3_to_ECU: 64 BCU
  SG_ Cell_64_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_64_Temp : 8|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
  SG_ Cell_65_Voltage : 16|8@1+ (0.01,2) [2|4.55] "Volts" ECU
@@ -213,7 +213,7 @@ BO_ 2147684098 BCU_BCU_Cell_Data_3_to_ECU: 64 BCU
  SG_ Cell_95_Voltage : 496|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_95_Temp : 504|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
 
-BO_ 2147684354 BCU_BCU_Cell_Data_4_to_ECU: 64 BCU
+BO_ 2150633474 BCU_BCU_Cell_Data_4_to_ECU: 64 BCU
  SG_ Cell_96_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_96_Temp : 8|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
  SG_ Cell_97_Voltage : 16|8@1+ (0.01,2) [2|4.55] "Volts" ECU
@@ -279,7 +279,7 @@ BO_ 2147684354 BCU_BCU_Cell_Data_4_to_ECU: 64 BCU
  SG_ Cell_127_Voltage : 496|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_127_Temp : 504|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
 
-BO_ 2147684610 BCU_BCU_Cell_Data_5_to_ECU: 64 BCU
+BO_ 2150633730 BCU_BCU_Cell_Data_5_to_ECU: 64 BCU
  SG_ Cell_128_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_128_Temp : 8|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
  SG_ Cell_129_Voltage : 16|8@1+ (0.01,2) [2|4.55] "Volts" ECU
@@ -345,31 +345,31 @@ BO_ 2147684610 BCU_BCU_Cell_Data_5_to_ECU: 64 BCU
  SG_ Cell_159_Voltage : 496|8@1+ (0.01,2) [2|4.55] "Volts" ECU
  SG_ Cell_159_Temp : 504|8@1+ (0.25,0) [0|63.75] "Celsius" ECU
 
-BO_ 2147549442 Debugger_Debug_FD_to_ECU: 64 Debugger
+BO_ 2148532482 Debugger_Debug_FD_to_ECU: 64 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" ECU
 
-BO_ 2147549698 Debugger_Ping_to_ECU: 4 Debugger
+BO_ 2148532738 Debugger_Ping_to_ECU: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2147549443 Debugger_Debug_FD_to_BCU: 64 Debugger
+BO_ 2148532483 Debugger_Debug_FD_to_BCU: 64 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" BCU
 
-BO_ 2147549699 Debugger_Ping_to_BCU: 4 Debugger
+BO_ 2148532739 Debugger_Ping_to_BCU: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" BCU
 
-BO_ 2147549444 Debugger_Debug_FD_to_TCM: 64 Debugger
+BO_ 2148532484 Debugger_Debug_FD_to_TCM: 64 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" TCM
 
-BO_ 2147549700 Debugger_Ping_to_TCM: 4 Debugger
+BO_ 2148532740 Debugger_Ping_to_TCM: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TCM
 
-BO_ 2147614977 ECU_Debug_FD_to_Debugger: 64 ECU
+BO_ 2149581057 ECU_Debug_FD_to_Debugger: 64 ECU
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2147615233 ECU_Ping_to_Debugger: 4 ECU
+BO_ 2149581313 ECU_Ping_to_Debugger: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147626500 ECU_ECU_Analog_Data_to_TCM: 16 ECU
+BO_ 2149592580 ECU_ECU_Analog_Data_to_TCM: 16 ECU
  SG_ BSPD_Signal : 0|16@1+ (0.0015259,0) [0|100] "%" TCM
  SG_ BSE_Signal : 16|16@1+ (0.0015259,0) [0|100] "%" TCM
  SG_ APPS_1_Signal : 32|16@1+ (0.0015259,0) [0|100] "%" TCM
@@ -379,449 +379,449 @@ BO_ 2147626500 ECU_ECU_Analog_Data_to_TCM: 16 ECU
  SG_ Steering_Angle_Signal : 96|16@1+ (0.0015259,0) [0|100] "%" TCM
  SG_ AUX_Signal : 112|16@1+ (0.0015259,0) [0|100] "%" TCM
 
-BO_ 2147626756 ECU_ECU_Performance_to_TCM: 4 ECU
+BO_ 2149592836 ECU_ECU_Performance_to_TCM: 4 ECU
  SG_ Elapsed_Cycles : 0|32@1+ (1,0) [0|0] "Clock Cycles" TCM
 
-BO_ 2147615264 ECU_Ping_to_SAMM_Mag_1: 4 ECU
+BO_ 2149581344 ECU_Ping_to_SAMM_Mag_1: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" SAMM_Mag_1
 
-BO_ 2147615265 ECU_Ping_to_SAMM_Mag_2: 4 ECU
+BO_ 2149581345 ECU_Ping_to_SAMM_Mag_2: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" SAMM_Mag_2
 
-BO_ 2147615266 ECU_Ping_to_SAMM_ToF_1: 4 ECU
+BO_ 2149581346 ECU_Ping_to_SAMM_ToF_1: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" SAMM_ToF_1
 
-BO_ 2147615267 ECU_Ping_to_SAMM_ToF_2: 4 ECU
+BO_ 2149581347 ECU_Ping_to_SAMM_ToF_2: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" SAMM_ToF_2
 
-BO_ 2147615268 ECU_Ping_to_TireTemp_FL: 4 ECU
+BO_ 2149581348 ECU_Ping_to_TireTemp_FL: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TireTemp_FL
 
-BO_ 2147615269 ECU_Ping_to_TireTemp_FR: 4 ECU
+BO_ 2149581349 ECU_Ping_to_TireTemp_FR: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TireTemp_FR
 
-BO_ 2147615270 ECU_Ping_to_TireTemp_RL: 4 ECU
+BO_ 2149581350 ECU_Ping_to_TireTemp_RL: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TireTemp_RL
 
-BO_ 2147615271 ECU_Ping_to_TireTemp_RR: 4 ECU
+BO_ 2149581351 ECU_Ping_to_TireTemp_RR: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TireTemp_RR
 
-BO_ 2147746305 TCM_Ping_to_Debugger: 4 TCM
+BO_ 2151678465 TCM_Ping_to_Debugger: 4 TCM
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2150642436 DGPS_GPS_ALT_to_TCM: 8 DGPS
+BO_ 2197828356 DGPS_GPS_ALT_to_TCM: 8 DGPS
  SG_ ALT : 0|64@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150641924 DGPS_GPS_LAT_to_TCM: 8 DGPS
+BO_ 2197827844 DGPS_GPS_LAT_to_TCM: 8 DGPS
  SG_ LAT : 0|64@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150642180 DGPS_GPS_LON_to_TCM: 8 DGPS
+BO_ 2197828100 DGPS_GPS_LON_to_TCM: 8 DGPS
  SG_ LON : 0|64@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150642692 DGPS_GPS_PX_to_TCM: 8 DGPS
+BO_ 2197828612 DGPS_GPS_PX_to_TCM: 8 DGPS
  SG_ Theta : 0|16@1- (0.001,0) [0|0] "" TCM
  SG_ Acc : 16|16@1- (0.01,0) [0|0] "" TCM
  SG_ status : 32|32@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150642948 DGPS_GPS_QY_to_TCM: 8 DGPS
+BO_ 2197828868 DGPS_GPS_QY_to_TCM: 8 DGPS
  SG_ Theta : 0|16@1- (0.001,0) [0|0] "" TCM
  SG_ Acc : 16|16@1- (0.01,0) [0|0] "" TCM
  SG_ status : 32|32@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150643204 DGPS_GPS_RZ_to_TCM: 8 DGPS
+BO_ 2197829124 DGPS_GPS_RZ_to_TCM: 8 DGPS
  SG_ Theta : 0|16@1- (0.001,0) [0|0] "" TCM
  SG_ Acc : 16|16@1- (0.01,0) [0|0] "" TCM
  SG_ status : 32|32@1+ (1,0) [0|0] "" TCM
 
-BO_ 2150641668 DGPS_UVW_DGPS_to_TCM: 6 DGPS
+BO_ 2197827588 DGPS_UVW_DGPS_to_TCM: 6 DGPS
  SG_ DGPS_U : 0|16@1- (0.01,0) [0|0] "" TCM
  SG_ DGPS_V : 16|16@1- (0.01,0) [0|0] "" TCM
  SG_ DGPS_W : 32|16@1- (0.01,0) [0|0] "" TCM
 
-BO_ 2149581314 SAMM_Mag_1_Ping_to_ECU: 4 SAMM_Mag_1
+BO_ 2181038594 SAMM_Mag_1_Ping_to_ECU: 4 SAMM_Mag_1
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149646850 SAMM_Mag_2_Ping_to_ECU: 4 SAMM_Mag_2
+BO_ 2182087170 SAMM_Mag_2_Ping_to_ECU: 4 SAMM_Mag_2
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149712386 SAMM_ToF_1_Ping_to_ECU: 4 SAMM_ToF_1
+BO_ 2183135746 SAMM_ToF_1_Ping_to_ECU: 4 SAMM_ToF_1
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149777922 SAMM_ToF_2_Ping_to_ECU: 4 SAMM_ToF_2
+BO_ 2184184322 SAMM_ToF_2_Ping_to_ECU: 4 SAMM_ToF_2
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149843458 TireTemp_FL_Ping_to_ECU: 4 TireTemp_FL
+BO_ 2185232898 TireTemp_FL_Ping_to_ECU: 4 TireTemp_FL
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149908994 TireTemp_FR_Ping_to_ECU: 4 TireTemp_FR
+BO_ 2186281474 TireTemp_FR_Ping_to_ECU: 4 TireTemp_FR
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2149974530 TireTemp_RL_Ping_to_ECU: 4 TireTemp_RL
+BO_ 2187330050 TireTemp_RL_Ping_to_ECU: 4 TireTemp_RL
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2150040066 TireTemp_RR_Ping_to_ECU: 4 TireTemp_RR
+BO_ 2188378626 TireTemp_RR_Ping_to_ECU: 4 TireTemp_RR
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-CM_ SG_ 2147680513 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
-CM_ SG_ 2147680769 Timestamp "Time in millis";
-CM_ SG_ 2147680770 Timestamp "Time in millis";
-CM_ SG_ 2147683586 Cell_0_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_0_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_1_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_1_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_2_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_2_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_3_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_3_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_4_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_4_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_5_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_5_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_6_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_6_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_7_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_7_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_8_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_8_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_9_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_9_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_10_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_10_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_11_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_11_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_12_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_12_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_13_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_13_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_14_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_14_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_15_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_15_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_16_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_16_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_17_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_17_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_18_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_18_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_19_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_19_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_20_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_20_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_21_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_21_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_22_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_22_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_23_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_23_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_24_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_24_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_25_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_25_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_26_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_26_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_27_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_27_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_28_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_28_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_29_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_29_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_30_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_30_Temp "Cell n temperature";
-CM_ SG_ 2147683586 Cell_31_Voltage "Cell  n voltage";
-CM_ SG_ 2147683586 Cell_31_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_32_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_32_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_33_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_33_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_34_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_34_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_35_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_35_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_36_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_36_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_37_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_37_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_38_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_38_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_39_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_39_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_40_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_40_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_41_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_41_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_42_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_42_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_43_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_43_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_44_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_44_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_45_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_45_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_46_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_46_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_47_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_47_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_48_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_48_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_49_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_49_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_50_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_50_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_51_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_51_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_52_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_52_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_53_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_53_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_54_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_54_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_55_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_55_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_56_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_56_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_57_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_57_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_58_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_58_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_59_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_59_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_60_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_60_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_61_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_61_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_62_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_62_Temp "Cell n temperature";
-CM_ SG_ 2147683842 Cell_63_Voltage "Cell  n voltage";
-CM_ SG_ 2147683842 Cell_63_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_64_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_64_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_65_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_65_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_66_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_66_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_67_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_67_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_68_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_68_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_69_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_69_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_70_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_70_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_71_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_71_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_72_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_72_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_73_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_73_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_74_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_74_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_75_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_75_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_76_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_76_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_77_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_77_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_78_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_78_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_79_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_79_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_80_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_80_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_81_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_81_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_82_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_82_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_83_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_83_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_84_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_84_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_85_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_85_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_86_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_86_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_87_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_87_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_88_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_88_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_89_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_89_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_90_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_90_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_91_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_91_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_92_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_92_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_93_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_93_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_94_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_94_Temp "Cell n temperature";
-CM_ SG_ 2147684098 Cell_95_Voltage "Cell  n voltage";
-CM_ SG_ 2147684098 Cell_95_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_96_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_96_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_97_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_97_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_98_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_98_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_99_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_99_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_100_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_100_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_101_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_101_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_102_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_102_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_103_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_103_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_104_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_104_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_105_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_105_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_106_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_106_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_107_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_107_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_108_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_108_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_109_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_109_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_110_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_110_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_111_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_111_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_112_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_112_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_113_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_113_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_114_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_114_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_115_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_115_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_116_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_116_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_117_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_117_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_118_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_118_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_119_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_119_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_120_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_120_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_121_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_121_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_122_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_122_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_123_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_123_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_124_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_124_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_125_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_125_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_126_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_126_Temp "Cell n temperature";
-CM_ SG_ 2147684354 Cell_127_Voltage "Cell  n voltage";
-CM_ SG_ 2147684354 Cell_127_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_128_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_128_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_129_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_129_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_130_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_130_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_131_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_131_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_132_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_132_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_133_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_133_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_134_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_134_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_135_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_135_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_136_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_136_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_137_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_137_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_138_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_138_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_139_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_139_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_140_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_140_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_141_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_141_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_142_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_142_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_143_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_143_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_144_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_144_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_145_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_145_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_146_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_146_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_147_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_147_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_148_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_148_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_149_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_149_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_150_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_150_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_151_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_151_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_152_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_152_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_153_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_153_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_154_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_154_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_155_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_155_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_156_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_156_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_157_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_157_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_158_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_158_Temp "Cell n temperature";
-CM_ SG_ 2147684610 Cell_159_Voltage "Cell  n voltage";
-CM_ SG_ 2147684610 Cell_159_Temp "Cell n temperature";
-CM_ SG_ 2147549442 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549698 Timestamp "Time in millis";
-CM_ SG_ 2147549443 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549699 Timestamp "Time in millis";
-CM_ SG_ 2147549444 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549700 Timestamp "Time in millis";
-CM_ SG_ 2147614977 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
-CM_ SG_ 2147615233 Timestamp "Time in millis";
-CM_ SG_ 2147626500 BSPD_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 BSE_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 APPS_1_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 APPS_2_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 Brakeline_F_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 Brakeline_R_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 Steering_Angle_Signal "4-20 mA signal";
-CM_ SG_ 2147626500 AUX_Signal "4-20 mA signal";
-CM_ SG_ 2147626756 Elapsed_Cycles "Represents the total number of clock cycles elapsed for 10 iterations of the main loop";
-CM_ SG_ 2147615264 Timestamp "Time in millis";
-CM_ SG_ 2147615265 Timestamp "Time in millis";
-CM_ SG_ 2147615266 Timestamp "Time in millis";
-CM_ SG_ 2147615267 Timestamp "Time in millis";
-CM_ SG_ 2147615268 Timestamp "Time in millis";
-CM_ SG_ 2147615269 Timestamp "Time in millis";
-CM_ SG_ 2147615270 Timestamp "Time in millis";
-CM_ SG_ 2147615271 Timestamp "Time in millis";
-CM_ SG_ 2147746305 Timestamp "Time in millis";
-CM_ SG_ 2150642436 ALT "altitude";
-CM_ SG_ 2150641924 LAT "lattitude";
-CM_ SG_ 2150642180 LON "longitude";
-CM_ SG_ 2150641668 DGPS_U "U";
-CM_ SG_ 2150641668 DGPS_V "V";
-CM_ SG_ 2150641668 DGPS_W "W";
-CM_ SG_ 2149581314 Timestamp "Time in millis";
-CM_ SG_ 2149646850 Timestamp "Time in millis";
-CM_ SG_ 2149712386 Timestamp "Time in millis";
-CM_ SG_ 2149777922 Timestamp "Time in millis";
-CM_ SG_ 2149843458 Timestamp "Time in millis";
-CM_ SG_ 2149908994 Timestamp "Time in millis";
-CM_ SG_ 2149974530 Timestamp "Time in millis";
-CM_ SG_ 2150040066 Timestamp "Time in millis";
+CM_ SG_ 2150629633 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
+CM_ SG_ 2150629889 Timestamp "Time in millis";
+CM_ SG_ 2150629890 Timestamp "Time in millis";
+CM_ SG_ 2150632706 Cell_0_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_0_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_1_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_1_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_2_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_2_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_3_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_3_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_4_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_4_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_5_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_5_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_6_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_6_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_7_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_7_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_8_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_8_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_9_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_9_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_10_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_10_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_11_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_11_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_12_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_12_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_13_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_13_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_14_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_14_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_15_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_15_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_16_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_16_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_17_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_17_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_18_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_18_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_19_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_19_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_20_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_20_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_21_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_21_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_22_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_22_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_23_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_23_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_24_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_24_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_25_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_25_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_26_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_26_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_27_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_27_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_28_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_28_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_29_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_29_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_30_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_30_Temp "Cell n temperature";
+CM_ SG_ 2150632706 Cell_31_Voltage "Cell  n voltage";
+CM_ SG_ 2150632706 Cell_31_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_32_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_32_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_33_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_33_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_34_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_34_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_35_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_35_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_36_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_36_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_37_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_37_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_38_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_38_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_39_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_39_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_40_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_40_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_41_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_41_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_42_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_42_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_43_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_43_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_44_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_44_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_45_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_45_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_46_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_46_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_47_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_47_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_48_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_48_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_49_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_49_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_50_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_50_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_51_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_51_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_52_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_52_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_53_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_53_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_54_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_54_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_55_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_55_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_56_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_56_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_57_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_57_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_58_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_58_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_59_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_59_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_60_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_60_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_61_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_61_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_62_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_62_Temp "Cell n temperature";
+CM_ SG_ 2150632962 Cell_63_Voltage "Cell  n voltage";
+CM_ SG_ 2150632962 Cell_63_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_64_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_64_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_65_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_65_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_66_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_66_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_67_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_67_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_68_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_68_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_69_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_69_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_70_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_70_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_71_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_71_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_72_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_72_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_73_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_73_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_74_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_74_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_75_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_75_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_76_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_76_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_77_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_77_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_78_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_78_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_79_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_79_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_80_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_80_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_81_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_81_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_82_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_82_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_83_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_83_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_84_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_84_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_85_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_85_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_86_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_86_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_87_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_87_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_88_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_88_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_89_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_89_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_90_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_90_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_91_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_91_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_92_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_92_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_93_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_93_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_94_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_94_Temp "Cell n temperature";
+CM_ SG_ 2150633218 Cell_95_Voltage "Cell  n voltage";
+CM_ SG_ 2150633218 Cell_95_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_96_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_96_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_97_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_97_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_98_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_98_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_99_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_99_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_100_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_100_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_101_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_101_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_102_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_102_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_103_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_103_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_104_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_104_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_105_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_105_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_106_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_106_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_107_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_107_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_108_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_108_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_109_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_109_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_110_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_110_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_111_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_111_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_112_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_112_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_113_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_113_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_114_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_114_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_115_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_115_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_116_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_116_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_117_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_117_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_118_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_118_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_119_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_119_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_120_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_120_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_121_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_121_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_122_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_122_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_123_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_123_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_124_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_124_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_125_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_125_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_126_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_126_Temp "Cell n temperature";
+CM_ SG_ 2150633474 Cell_127_Voltage "Cell  n voltage";
+CM_ SG_ 2150633474 Cell_127_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_128_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_128_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_129_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_129_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_130_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_130_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_131_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_131_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_132_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_132_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_133_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_133_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_134_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_134_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_135_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_135_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_136_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_136_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_137_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_137_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_138_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_138_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_139_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_139_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_140_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_140_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_141_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_141_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_142_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_142_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_143_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_143_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_144_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_144_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_145_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_145_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_146_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_146_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_147_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_147_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_148_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_148_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_149_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_149_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_150_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_150_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_151_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_151_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_152_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_152_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_153_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_153_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_154_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_154_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_155_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_155_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_156_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_156_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_157_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_157_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_158_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_158_Temp "Cell n temperature";
+CM_ SG_ 2150633730 Cell_159_Voltage "Cell  n voltage";
+CM_ SG_ 2150633730 Cell_159_Temp "Cell n temperature";
+CM_ SG_ 2148532482 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532738 Timestamp "Time in millis";
+CM_ SG_ 2148532483 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532739 Timestamp "Time in millis";
+CM_ SG_ 2148532484 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532740 Timestamp "Time in millis";
+CM_ SG_ 2149581057 Debug "Essentially a print statement up to 64 bytes long that whichever targeted can parse";
+CM_ SG_ 2149581313 Timestamp "Time in millis";
+CM_ SG_ 2149592580 BSPD_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 BSE_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 APPS_1_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 APPS_2_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 Brakeline_F_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 Brakeline_R_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 Steering_Angle_Signal "4-20 mA signal";
+CM_ SG_ 2149592580 AUX_Signal "4-20 mA signal";
+CM_ SG_ 2149592836 Elapsed_Cycles "Represents the total number of clock cycles elapsed for 10 iterations of the main loop";
+CM_ SG_ 2149581344 Timestamp "Time in millis";
+CM_ SG_ 2149581345 Timestamp "Time in millis";
+CM_ SG_ 2149581346 Timestamp "Time in millis";
+CM_ SG_ 2149581347 Timestamp "Time in millis";
+CM_ SG_ 2149581348 Timestamp "Time in millis";
+CM_ SG_ 2149581349 Timestamp "Time in millis";
+CM_ SG_ 2149581350 Timestamp "Time in millis";
+CM_ SG_ 2149581351 Timestamp "Time in millis";
+CM_ SG_ 2151678465 Timestamp "Time in millis";
+CM_ SG_ 2197828356 ALT "altitude";
+CM_ SG_ 2197827844 LAT "lattitude";
+CM_ SG_ 2197828100 LON "longitude";
+CM_ SG_ 2197827588 DGPS_U "U";
+CM_ SG_ 2197827588 DGPS_V "V";
+CM_ SG_ 2197827588 DGPS_W "W";
+CM_ SG_ 2181038594 Timestamp "Time in millis";
+CM_ SG_ 2182087170 Timestamp "Time in millis";
+CM_ SG_ 2183135746 Timestamp "Time in millis";
+CM_ SG_ 2184184322 Timestamp "Time in millis";
+CM_ SG_ 2185232898 Timestamp "Time in millis";
+CM_ SG_ 2186281474 Timestamp "Time in millis";
+CM_ SG_ 2187330050 Timestamp "Time in millis";
+CM_ SG_ 2188378626 Timestamp "Time in millis";

--- a/Autogen/CAN/Doc/GRCAN_Primary.dbc
+++ b/Autogen/CAN/Doc/GRCAN_Primary.dbc
@@ -6,23 +6,23 @@ BS_:
 
 BU_: BCU DTI_Inverter Dash_Panel Debugger ECU Fan_Controller_1 Fan_Controller_2 Fan_Controller_3 GR_Inverter TCM ALL
 
-BO_ 2147680257 BCU_Debug_2_0_to_Debugger: 8 BCU
+BO_ 2150629377 BCU_Debug_2_0_to_Debugger: 8 BCU
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2147680769 BCU_Ping_to_Debugger: 4 BCU
+BO_ 2150629889 BCU_Ping_to_Debugger: 4 BCU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147680770 BCU_Ping_to_ECU: 4 BCU
+BO_ 2150629890 BCU_Ping_to_ECU: 4 BCU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2147682050 BCU_BCU_Status_1_to_ECU: 8 BCU
+BO_ 2150631170 BCU_BCU_Status_1_to_ECU: 8 BCU
  SG_ Accumulator_Voltage : 0|16@1+ (0.01,0) [0|655.35] "Volts" ECU
  SG_ TS_Voltage : 16|16@1+ (0.01,0) [0|655.35] "Volts" ECU
  SG_ Accumulator_Current : 32|16@1- (0.01,0) [-327.68|327.67] "Amps" ECU
  SG_ Accumulator_SOC : 48|8@1+ (0.392157,0) [0|100] "%" ECU
  SG_ GLV_SOC : 56|8@1+ (0.392157,0) [0|100] "%" ECU
 
-BO_ 2147682306 BCU_BCU_Status_2_to_ECU: 7 BCU
+BO_ 2150631426 BCU_BCU_Status_2_to_ECU: 7 BCU
  SG_ _20v_Voltage : 0|8@1+ (1,0) [0|0] "" ECU
  SG_ _12v_Voltage : 8|8@1+ (1,0) [0|0] "" ECU
  SG_ SDC_Voltage : 16|8@1+ (1,0) [0|0] "" ECU
@@ -31,71 +31,71 @@ BO_ 2147682306 BCU_BCU_Status_2_to_ECU: 7 BCU
  SG_ status_flags : 40|1@1+ (1,0) [0|0] "" ECU
  SG_ precharge_latch_flags : 48|1@1+ (1,0) [0|0] "" ECU
 
-BO_ 2147682562 BCU_BCU_Status_3_to_ECU: 8 BCU
+BO_ 2150631682 BCU_BCU_Status_3_to_ECU: 8 BCU
  SG_ HV_Input_Voltage : 0|16@1+ (0.01,0) [0|655.35] "Volts" ECU
  SG_ HV_Output_Voltage : 16|16@1+ (0.01,0) [0|655.35] "Volts" ECU
  SG_ HV_Input_Current : 32|16@1+ (0.001,0) [0|65.535] "Amps" ECU
  SG_ HV_Output_Current : 48|16@1+ (0.001,0) [0|65.535] "Amps" ECU
 
-BO_ 2147811329 Dash_Panel_Debug_2_0_to_Debugger: 8 Dash_Panel
+BO_ 2152726529 Dash_Panel_Debug_2_0_to_Debugger: 8 Dash_Panel
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2147811841 Dash_Panel_Ping_to_Debugger: 4 Dash_Panel
+BO_ 2152727041 Dash_Panel_Ping_to_Debugger: 4 Dash_Panel
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147811842 Dash_Panel_Ping_to_ECU: 4 Dash_Panel
+BO_ 2152727042 Dash_Panel_Ping_to_ECU: 4 Dash_Panel
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2147817986 Dash_Panel_Dash_Status_to_ECU: 3 Dash_Panel
+BO_ 2152733186 Dash_Panel_Dash_Status_to_ECU: 3 Dash_Panel
  SG_ button_flags : 0|8@1+ (1,0) [0|0] "" ECU
  SG_ led_bits : 8|8@1+ (1,0) [0|0] "" ECU
 
-BO_ 2147549186 Debugger_Debug_2_0_to_ECU: 8 Debugger
+BO_ 2148532226 Debugger_Debug_2_0_to_ECU: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" ECU
 
-BO_ 2147549698 Debugger_Ping_to_ECU: 4 Debugger
+BO_ 2148532738 Debugger_Ping_to_ECU: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2147549187 Debugger_Debug_2_0_to_BCU: 8 Debugger
+BO_ 2148532227 Debugger_Debug_2_0_to_BCU: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" BCU
 
-BO_ 2147549699 Debugger_Ping_to_BCU: 4 Debugger
+BO_ 2148532739 Debugger_Ping_to_BCU: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" BCU
 
-BO_ 2147549188 Debugger_Debug_2_0_to_TCM: 8 Debugger
+BO_ 2148532228 Debugger_Debug_2_0_to_TCM: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" TCM
 
-BO_ 2147549700 Debugger_Ping_to_TCM: 4 Debugger
+BO_ 2148532740 Debugger_Ping_to_TCM: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TCM
 
-BO_ 2147549189 Debugger_Debug_2_0_to_Dash_Panel: 8 Debugger
+BO_ 2148532229 Debugger_Debug_2_0_to_Dash_Panel: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Dash_Panel
 
-BO_ 2147549701 Debugger_Ping_to_Dash_Panel: 4 Debugger
+BO_ 2148532741 Debugger_Ping_to_Dash_Panel: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Dash_Panel
 
-BO_ 2147549192 Debugger_Debug_2_0_to_GR_Inverter: 8 Debugger
+BO_ 2148532232 Debugger_Debug_2_0_to_GR_Inverter: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" GR_Inverter
 
-BO_ 2147549704 Debugger_Ping_to_GR_Inverter: 4 Debugger
+BO_ 2148532744 Debugger_Ping_to_GR_Inverter: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" GR_Inverter
 
-BO_ 2147549197 Debugger_Debug_2_0_to_Fan_Controller_1: 8 Debugger
+BO_ 2148532237 Debugger_Debug_2_0_to_Fan_Controller_1: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Fan_Controller_1
 
-BO_ 2147549709 Debugger_Ping_to_Fan_Controller_1: 4 Debugger
+BO_ 2148532749 Debugger_Ping_to_Fan_Controller_1: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_1
 
-BO_ 2147549198 Debugger_Debug_2_0_to_Fan_Controller_2: 8 Debugger
+BO_ 2148532238 Debugger_Debug_2_0_to_Fan_Controller_2: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Fan_Controller_2
 
-BO_ 2147549710 Debugger_Ping_to_Fan_Controller_2: 4 Debugger
+BO_ 2148532750 Debugger_Ping_to_Fan_Controller_2: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_2
 
-BO_ 2147549199 Debugger_Debug_2_0_to_Fan_Controller_3: 8 Debugger
+BO_ 2148532239 Debugger_Debug_2_0_to_Fan_Controller_3: 8 Debugger
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Fan_Controller_3
 
-BO_ 2147549711 Debugger_Ping_to_Fan_Controller_3: 4 Debugger
+BO_ 2148532751 Debugger_Ping_to_Fan_Controller_3: 4 Debugger
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_3
 
 BO_ 2147491862 DTI_Inverter_DTI_Data_1_to_ECU: 8 DTI_Inverter
@@ -180,67 +180,67 @@ BO_ 2147486486 ECU_DTI_Control_11_to_DTI_Inverter: 2 ECU
 BO_ 2147486742 ECU_DTI_Control_12_to_DTI_Inverter: 1 ECU
  SG_ Drive_Enable : 0|8@1+ (1,0) [0|0] "" DTI_Inverter
 
-BO_ 2147614721 ECU_Debug_2_0_to_Debugger: 8 ECU
+BO_ 2149580801 ECU_Debug_2_0_to_Debugger: 8 ECU
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2147615233 ECU_Ping_to_Debugger: 4 ECU
+BO_ 2149581313 ECU_Ping_to_Debugger: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147617283 ECU_BCU_Precharge_to_BCU: 1 ECU
+BO_ 2149583363 ECU_BCU_Precharge_to_BCU: 1 ECU
  SG_ Set_TS_Active : 0|1@1+ (1,0) [0|0] "Bool" BCU
 
-BO_ 2147617539 ECU_BCU_Config_Charge_Parameters_to_BCU: 4 ECU
+BO_ 2149583619 ECU_BCU_Config_Charge_Parameters_to_BCU: 4 ECU
  SG_ Charge_Voltage : 0|16@1+ (0.1,0) [0|6553.5] "Volts" BCU
  SG_ Charge_Current : 16|16@1+ (0.1,0) [0|6553.5] "Amps" BCU
 
-BO_ 2147617795 ECU_BCU_Config_Operational_Parameters_to_BCU: 2 ECU
+BO_ 2149583875 ECU_BCU_Config_Operational_Parameters_to_BCU: 2 ECU
  SG_ Minimium_Cell_Voltage : 0|8@1+ (0.01,2) [2|4.55] "Volts" BCU
  SG_ Max_Cell_Temperature : 8|8@1+ (0.25,0) [0|63.75] "Celsius" BCU
 
-BO_ 2147615235 ECU_Ping_to_BCU: 4 ECU
+BO_ 2149581315 ECU_Ping_to_BCU: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" BCU
 
-BO_ 2147620360 ECU_Inverter_Config_to_GR_Inverter: 7 ECU
+BO_ 2149586440 ECU_Inverter_Config_to_GR_Inverter: 7 ECU
  SG_ Max_AC_Current : 0|16@1+ (0.01,-327.68) [-327.68|327.67] "Amps" GR_Inverter
  SG_ Max_DC_Current : 16|16@1+ (0.01,-327.68) [-327.68|327.67] "Amps" GR_Inverter
  SG_ Absolute_Max_RPM_Limit : 32|16@1+ (1,-32768) [-32768|32767] "RPM" GR_Inverter
  SG_ Motor_direction : 48|1@1+ (1,0) [0|0] "Enable" GR_Inverter
 
-BO_ 2147620616 ECU_Inverter_Command_to_GR_Inverter: 8 ECU
+BO_ 2149586696 ECU_Inverter_Command_to_GR_Inverter: 8 ECU
  SG_ Set_AC_Current : 0|16@1+ (0.01,-327.68) [-327.68|327.67] "Amps" GR_Inverter
  SG_ Set_DC_Current : 16|16@1+ (0.01,-327.68) [-327.68|327.67] "Amps" GR_Inverter
  SG_ RPM_Limit : 32|16@1+ (1,-32768) [-32768|32767] "RPM" GR_Inverter
  SG_ Field_weakening : 48|8@1+ (0.1,0) [0|25.5] "Amps" GR_Inverter
  SG_ Drive_enable : 56|1@1+ (1,0) [0|0] "Enable" GR_Inverter
 
-BO_ 2147615240 ECU_Ping_to_GR_Inverter: 4 ECU
+BO_ 2149581320 ECU_Ping_to_GR_Inverter: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" GR_Inverter
 
-BO_ 2147621133 ECU_Fan_Command_to_Fan_Controller_1: 1 ECU
+BO_ 2149587213 ECU_Fan_Command_to_Fan_Controller_1: 1 ECU
  SG_ Fan_Command : 0|8@1+ (1,0) [0|255] "%" Fan_Controller_1
 
-BO_ 2147615245 ECU_Ping_to_Fan_Controller_1: 4 ECU
+BO_ 2149581325 ECU_Ping_to_Fan_Controller_1: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_1
 
-BO_ 2147621134 ECU_Fan_Command_to_Fan_Controller_2: 1 ECU
+BO_ 2149587214 ECU_Fan_Command_to_Fan_Controller_2: 1 ECU
  SG_ Fan_Command : 0|8@1+ (1,0) [0|255] "%" Fan_Controller_2
 
-BO_ 2147615246 ECU_Ping_to_Fan_Controller_2: 4 ECU
+BO_ 2149581326 ECU_Ping_to_Fan_Controller_2: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_2
 
-BO_ 2147621135 ECU_Fan_Command_to_Fan_Controller_3: 1 ECU
+BO_ 2149587215 ECU_Fan_Command_to_Fan_Controller_3: 1 ECU
  SG_ Fan_Command : 0|8@1+ (1,0) [0|255] "%" Fan_Controller_3
 
-BO_ 2147615247 ECU_Ping_to_Fan_Controller_3: 4 ECU
+BO_ 2149581327 ECU_Ping_to_Fan_Controller_3: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Fan_Controller_3
 
-BO_ 2147621637 ECU_Dash_Config_to_Dash_Panel: 1 ECU
+BO_ 2149587717 ECU_Dash_Config_to_Dash_Panel: 1 ECU
  SG_ led_bits : 0|8@1+ (1,0) [0|0] "" Dash_Panel
 
-BO_ 2147615237 ECU_Ping_to_Dash_Panel: 4 ECU
+BO_ 2149581317 ECU_Ping_to_Dash_Panel: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Dash_Panel
 
-BO_ 2147615488 ECU_ECU_Status_1_to_ALL: 8 ECU
+BO_ 2149581568 ECU_ECU_Status_1_to_ALL: 8 ECU
  SG_ status_flags : 0|16@1+ (1,0) [0|0] "" ALL
  SG_ ecu_state : 16|1@1+ (1,0) [0|0] "Bool" ALL
  SG_ Power_Level : 24|4@1+ (1,0) [0|0] "" ALL
@@ -249,130 +249,130 @@ BO_ 2147615488 ECU_ECU_Status_1_to_ALL: 8 ECU
  SG_ Accumulator_State_of_Charge : 40|8@1+ (0.392157,0) [0|100] "%" ALL
  SG_ GLV_State_of_Charge : 48|8@1+ (0.392157,0) [0|100] "%" ALL
 
-BO_ 2147615744 ECU_ECU_Status_2_to_ALL: 8 ECU
+BO_ 2149581824 ECU_ECU_Status_2_to_ALL: 8 ECU
  SG_ Vehicle_Speed : 0|16@1+ (0.01,0) [0|655.35] "MPH" ALL
  SG_ Tractive_System_Voltage : 16|16@1+ (0.01,0) [0|655.35] "Volts" ALL
  SG_ FR_Wheel_RPM : 32|16@1+ (0.1,-3276.8) [-3276.8|3276.7] "RPM" ALL
  SG_ FL_Wheel_RPM : 48|16@1+ (0.1,-3276.8) [-3276.8|3276.7] "RPM" ALL
 
-BO_ 2147616000 ECU_ECU_Status_3_to_ALL: 4 ECU
+BO_ 2149582080 ECU_ECU_Status_3_to_ALL: 4 ECU
  SG_ RR_Wheel_RPM : 0|16@1+ (0.1,-3276.8) [-3276.8|3276.7] "RPM" ALL
  SG_ RL_Wheel_RPM : 16|16@1+ (0.1,-3276.8) [-3276.8|3276.7] "RPM" ALL
 
-BO_ 2147615236 ECU_Ping_to_TCM: 4 ECU
+BO_ 2149581316 ECU_Ping_to_TCM: 4 ECU
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" TCM
 
-BO_ 2148335617 Fan_Controller_1_Debug_2_0_to_Debugger: 8 Fan_Controller_1
+BO_ 2161115137 Fan_Controller_1_Debug_2_0_to_Debugger: 8 Fan_Controller_1
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2148336129 Fan_Controller_1_Ping_to_Debugger: 4 Fan_Controller_1
+BO_ 2161115649 Fan_Controller_1_Ping_to_Debugger: 4 Fan_Controller_1
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2148336130 Fan_Controller_1_Ping_to_ECU: 4 Fan_Controller_1
+BO_ 2161115650 Fan_Controller_1_Ping_to_ECU: 4 Fan_Controller_1
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2148341762 Fan_Controller_1_Fan_Status_to_ECU: 4 Fan_Controller_1
+BO_ 2161121282 Fan_Controller_1_Fan_Status_to_ECU: 4 Fan_Controller_1
  SG_ Fan_Speed : 0|16@1+ (1,0) [0|65535] "RPM" ECU
  SG_ Input_Voltage : 16|8@1+ (0.1,0) [0|25.5] "Volts" ECU
  SG_ Input_Current : 24|8@1+ (0.1,0) [0|25.5] "Amps" ECU
 
-BO_ 2148401153 Fan_Controller_2_Debug_2_0_to_Debugger: 8 Fan_Controller_2
+BO_ 2162163713 Fan_Controller_2_Debug_2_0_to_Debugger: 8 Fan_Controller_2
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2148401665 Fan_Controller_2_Ping_to_Debugger: 4 Fan_Controller_2
+BO_ 2162164225 Fan_Controller_2_Ping_to_Debugger: 4 Fan_Controller_2
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2148401666 Fan_Controller_2_Ping_to_ECU: 4 Fan_Controller_2
+BO_ 2162164226 Fan_Controller_2_Ping_to_ECU: 4 Fan_Controller_2
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2148407298 Fan_Controller_2_Fan_Status_to_ECU: 4 Fan_Controller_2
+BO_ 2162169858 Fan_Controller_2_Fan_Status_to_ECU: 4 Fan_Controller_2
  SG_ Fan_Speed : 0|16@1+ (1,0) [0|65535] "RPM" ECU
  SG_ Input_Voltage : 16|8@1+ (0.1,0) [0|25.5] "Volts" ECU
  SG_ Input_Current : 24|8@1+ (0.1,0) [0|25.5] "Amps" ECU
 
-BO_ 2148466689 Fan_Controller_3_Debug_2_0_to_Debugger: 8 Fan_Controller_3
+BO_ 2163212289 Fan_Controller_3_Debug_2_0_to_Debugger: 8 Fan_Controller_3
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2148467201 Fan_Controller_3_Ping_to_Debugger: 4 Fan_Controller_3
+BO_ 2163212801 Fan_Controller_3_Ping_to_Debugger: 4 Fan_Controller_3
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2148467202 Fan_Controller_3_Ping_to_ECU: 4 Fan_Controller_3
+BO_ 2163212802 Fan_Controller_3_Ping_to_ECU: 4 Fan_Controller_3
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2148472834 Fan_Controller_3_Fan_Status_to_ECU: 4 Fan_Controller_3
+BO_ 2163218434 Fan_Controller_3_Fan_Status_to_ECU: 4 Fan_Controller_3
  SG_ Fan_Speed : 0|16@1+ (1,0) [0|65535] "RPM" ECU
  SG_ Input_Voltage : 16|8@1+ (0.1,0) [0|25.5] "Volts" ECU
  SG_ Input_Current : 24|8@1+ (0.1,0) [0|25.5] "Amps" ECU
 
-BO_ 2148007937 GR_Inverter_Debug_2_0_to_Debugger: 8 GR_Inverter
+BO_ 2155872257 GR_Inverter_Debug_2_0_to_Debugger: 8 GR_Inverter
  SG_ Debug : 0|64@1- (1,0) [0|0] "" Debugger
 
-BO_ 2148008449 GR_Inverter_Ping_to_Debugger: 4 GR_Inverter
+BO_ 2155872769 GR_Inverter_Ping_to_Debugger: 4 GR_Inverter
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2148008450 GR_Inverter_Ping_to_ECU: 4 GR_Inverter
+BO_ 2155872770 GR_Inverter_Ping_to_ECU: 4 GR_Inverter
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-BO_ 2148012802 GR_Inverter_Inverter_Status_1_to_ECU: 6 GR_Inverter
+BO_ 2155877122 GR_Inverter_Inverter_Status_1_to_ECU: 6 GR_Inverter
  SG_ AC_current : 0|16@1+ (0.01,-327.68) [-327.68|327.67] "Amps" ECU
  SG_ DC_current : 16|16@1+ (0.01,0) [0|655.35] "Amps" ECU
  SG_ Motor_RPM : 32|16@1+ (1,-32768) [-32768|32767] "RPM" ECU
 
-BO_ 2148013058 GR_Inverter_Inverter_Status_2_to_ECU: 6 GR_Inverter
+BO_ 2155877378 GR_Inverter_Inverter_Status_2_to_ECU: 6 GR_Inverter
  SG_ U_MOSFET_temperature : 0|8@1+ (1,-40) [-40|215] "Celsius" ECU
  SG_ V_MOSFET_temperature : 16|8@1+ (1,-40) [-40|215] "Celsius" ECU
  SG_ W_MOSFET_temperature : 32|8@1+ (1,-40) [-40|215] "Celsius" ECU
 
-BO_ 2148013314 GR_Inverter_Inverter_Status_3_to_ECU: 3 GR_Inverter
+BO_ 2155877634 GR_Inverter_Inverter_Status_3_to_ECU: 3 GR_Inverter
  SG_ Motor_temperature : 0|8@1+ (1,-40) [-40|215] "Celsius" ECU
  SG_ fault_bits : 16|8@1+ (1,0) [0|0] "" ECU
 
-BO_ 2147746305 TCM_Ping_to_Debugger: 4 TCM
+BO_ 2151678465 TCM_Ping_to_Debugger: 4 TCM
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" Debugger
 
-BO_ 2147746306 TCM_Ping_to_ECU: 4 TCM
+BO_ 2151678466 TCM_Ping_to_ECU: 4 TCM
  SG_ Timestamp : 0|32@1+ (1,0) [0|4.29497e+09] "ms" ECU
 
-CM_ SG_ 2147680257 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147680769 Timestamp "Time in millis";
-CM_ SG_ 2147680770 Timestamp "Time in millis";
-CM_ SG_ 2147682050 Accumulator_Voltage "All cell voltages added up";
-CM_ SG_ 2147682050 TS_Voltage "Output terminal voltage of accumulator";
-CM_ SG_ 2147682050 Accumulator_Current "Current output of accumulator";
-CM_ SG_ 2147682050 Accumulator_SOC "Accumulator state of charge (Based on lowest cell)";
-CM_ SG_ 2147682050 GLV_SOC "GLV state of charge";
-CM_ SG_ 2147682306 _20v_Voltage "20v GLV voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 _12v_Voltage "12v supply voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 SDC_Voltage "Voltage before BCU Latch data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
-CM_ SG_ 2147682306 Min_Cell_Voltage "Lowest cell voltage in accumulator data type: u8 units: Volts scaled min: 2 scaled max: 4.55 map equation: \"0.01x+2\"";
-CM_ SG_ 2147682306 Max_Cell_Temp "Hottest cell in accumulator data type: u8 units: Celsius scaled min: 0 scaled max: 63.75 map equation: \"0.25x\"";
-CM_ SG_ 2147682306 status_flags "[Byte 5 / Bits 40-47] 40: Over Temp (>60C) 41: Over Voltage (>4.2V/cell) 42: Under Volt (<2.5V/cell) 43: Over Current (Discharge) 44: Under Current (Charge) 45: 20V GLV Warning 46: 12V Supply Warning 47: SDC Warning";
-CM_ SG_ 2147682306 precharge_latch_flags "[Byte 6 / Bits 48-55] 48: Precharge Timeout 49: IR- / Precharge State (0:Open, 1:Closed) 50: IR+ State (0:Open, 1:Closed) 51: Software Latch (0:Open, 1:Closed) 52-55: Reserved";
-CM_ SG_ 2147682562 HV_Input_Voltage "600v input voltage";
-CM_ SG_ 2147682562 HV_Output_Voltage "20v output voltage";
-CM_ SG_ 2147682562 HV_Input_Current "600v input current";
-CM_ SG_ 2147682562 HV_Output_Current "20v output current";
-CM_ SG_ 2147811329 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147811841 Timestamp "Time in millis";
-CM_ SG_ 2147811842 Timestamp "Time in millis";
-CM_ SG_ 2147817986 button_flags "[Byte 0 / Bits 0-7] 0: TS Active 1: RTD 2-7: Reserved";
-CM_ SG_ 2147817986 led_bits "[Byte 1 / Bits 8-15] 0: BMS 1: IMD 2: BSPD 3-7: Reserved";
-CM_ SG_ 2147549186 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549698 Timestamp "Time in millis";
-CM_ SG_ 2147549187 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549699 Timestamp "Time in millis";
-CM_ SG_ 2147549188 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549700 Timestamp "Time in millis";
-CM_ SG_ 2147549189 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549701 Timestamp "Time in millis";
-CM_ SG_ 2147549192 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549704 Timestamp "Time in millis";
-CM_ SG_ 2147549197 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549709 Timestamp "Time in millis";
-CM_ SG_ 2147549198 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549710 Timestamp "Time in millis";
-CM_ SG_ 2147549199 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147549711 Timestamp "Time in millis";
+CM_ SG_ 2150629377 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2150629889 Timestamp "Time in millis";
+CM_ SG_ 2150629890 Timestamp "Time in millis";
+CM_ SG_ 2150631170 Accumulator_Voltage "All cell voltages added up";
+CM_ SG_ 2150631170 TS_Voltage "Output terminal voltage of accumulator";
+CM_ SG_ 2150631170 Accumulator_Current "Current output of accumulator";
+CM_ SG_ 2150631170 Accumulator_SOC "Accumulator state of charge (Based on lowest cell)";
+CM_ SG_ 2150631170 GLV_SOC "GLV state of charge";
+CM_ SG_ 2150631426 _20v_Voltage "20v GLV voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 _12v_Voltage "12v supply voltage data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 SDC_Voltage "Voltage before BCU Latch data type: u8 units: Volts scaled min: 0 scaled max: 25.5 map equation: \"0.1x\"";
+CM_ SG_ 2150631426 Min_Cell_Voltage "Lowest cell voltage in accumulator data type: u8 units: Volts scaled min: 2 scaled max: 4.55 map equation: \"0.01x+2\"";
+CM_ SG_ 2150631426 Max_Cell_Temp "Hottest cell in accumulator data type: u8 units: Celsius scaled min: 0 scaled max: 63.75 map equation: \"0.25x\"";
+CM_ SG_ 2150631426 status_flags "[Byte 5 / Bits 40-47] 40: Over Temp (>60C) 41: Over Voltage (>4.2V/cell) 42: Under Volt (<2.5V/cell) 43: Over Current (Discharge) 44: Under Current (Charge) 45: 20V GLV Warning 46: 12V Supply Warning 47: SDC Warning";
+CM_ SG_ 2150631426 precharge_latch_flags "[Byte 6 / Bits 48-55] 48: Precharge Timeout 49: IR- / Precharge State (0:Open, 1:Closed) 50: IR+ State (0:Open, 1:Closed) 51: Software Latch (0:Open, 1:Closed) 52-55: Reserved";
+CM_ SG_ 2150631682 HV_Input_Voltage "600v input voltage";
+CM_ SG_ 2150631682 HV_Output_Voltage "20v output voltage";
+CM_ SG_ 2150631682 HV_Input_Current "600v input current";
+CM_ SG_ 2150631682 HV_Output_Current "20v output current";
+CM_ SG_ 2152726529 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2152727041 Timestamp "Time in millis";
+CM_ SG_ 2152727042 Timestamp "Time in millis";
+CM_ SG_ 2152733186 button_flags "[Byte 0 / Bits 0-7] 0: TS Active 1: RTD 2-7: Reserved";
+CM_ SG_ 2152733186 led_bits "[Byte 1 / Bits 8-15] 0: BMS 1: IMD 2: BSPD 3-7: Reserved";
+CM_ SG_ 2148532226 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532738 Timestamp "Time in millis";
+CM_ SG_ 2148532227 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532739 Timestamp "Time in millis";
+CM_ SG_ 2148532228 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532740 Timestamp "Time in millis";
+CM_ SG_ 2148532229 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532741 Timestamp "Time in millis";
+CM_ SG_ 2148532232 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532744 Timestamp "Time in millis";
+CM_ SG_ 2148532237 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532749 Timestamp "Time in millis";
+CM_ SG_ 2148532238 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532750 Timestamp "Time in millis";
+CM_ SG_ 2148532239 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2148532751 Timestamp "Time in millis";
 CM_ SG_ 2147491862 ERPM "Electrical RPM Equation: ERPM = Motor RPM * number of the motor pole pairs.";
 CM_ SG_ 2147491862 Duty_Cycle "The controller duty cycle. The sign of this value will represent whether the motor is running(positive) current or regenerating (negative) current.";
 CM_ SG_ 2147491862 Input_Voltage "Input voltage is the DC voltage.";
@@ -415,74 +415,74 @@ CM_ SG_ 2147485974 Max_Brake_AC_Current "This value sets the maximum allowable b
 CM_ SG_ 2147486230 Max_DC_Current "This value determines the maximum allowable drive current on the DC side. With this command the BMS can limit the maximum allowable battery discharge current. The value has to be multiplied by 10 before sending.";
 CM_ SG_ 2147486486 Max_Brake_DC_Current "This value determines the maximum allowable brake current on the DC side. With this command the BMS can limit the maximum allowable battery charge current. The value has to be multiplied by 10 before sending. Only negative currents are accepted.";
 CM_ SG_ 2147486742 Drive_Enable "0: Drive not allowed 1: Drive allowed Only 0 and 1 values are accepted. Must be sent periodically to be enabled.";
-CM_ SG_ 2147614721 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2147615233 Timestamp "Time in millis";
-CM_ SG_ 2147617283 Set_TS_Active "0: shutdown, 1: go TS Active/Precharge";
-CM_ SG_ 2147617539 Charge_Voltage "Sets the Target Charging voltage";
-CM_ SG_ 2147617539 Charge_Current "Sets the Target Charging Current";
-CM_ SG_ 2147617795 Minimium_Cell_Voltage "Sets the threshold for Minimum Cell Voltage before Shutdown";
-CM_ SG_ 2147617795 Max_Cell_Temperature "Sets the threshold for Max Cell Temperature before Shutdown";
-CM_ SG_ 2147615235 Timestamp "Time in millis";
-CM_ SG_ 2147620360 Max_AC_Current "Max AC Current";
-CM_ SG_ 2147620360 Max_DC_Current "Max DC Current";
-CM_ SG_ 2147620360 Absolute_Max_RPM_Limit "0: No limit      n :limited at n RPM";
-CM_ SG_ 2147620360 Motor_direction "Write 1 inverts direction";
-CM_ SG_ 2147620616 Set_AC_Current "Commanded AC Current";
-CM_ SG_ 2147620616 Set_DC_Current "Commanded DC Current";
-CM_ SG_ 2147620616 RPM_Limit "0: No limit      n :limited at n RPM";
-CM_ SG_ 2147620616 Field_weakening "Field weakening strength";
-CM_ SG_ 2147620616 Drive_enable "Write this to 1 every 100ms to enable inverter";
-CM_ SG_ 2147615240 Timestamp "Time in millis";
-CM_ SG_ 2147621133 Fan_Command "0-100 Percent";
-CM_ SG_ 2147615245 Timestamp "Time in millis";
-CM_ SG_ 2147621134 Fan_Command "0-100 Percent";
-CM_ SG_ 2147615246 Timestamp "Time in millis";
-CM_ SG_ 2147621135 Fan_Command "0-100 Percent";
-CM_ SG_ 2147615247 Timestamp "Time in millis";
-CM_ SG_ 2147621637 led_bits "[Byte 0 / Bits 0-7] 0: BMS LED command 1: IMD LED command 2: BSPD LED command 3-7: Reserved";
-CM_ SG_ 2147615237 Timestamp "Time in millis";
-CM_ SG_ 2147615488 status_flags "[Bytes 0-1 / Bits 0-15] 0: BCU Node Status (1: OK, 0: Timeout) 1: GR Inverter Status (1: OK, 0: Timeout) 2: Fan Controller 1 Status (1: OK, 0: Timeout) 3: Fan Controller 2 Status (1: OK, 0: Timeout) 4: Fan Controller 3 Status (1: OK, 0: Timeout) 5: Dash Panel Status (1: OK, 0: Timeout) 6: TCM Node Status (1: OK, 0: Timeout) 7: SAMM_Mag_1 Status (1: OK, 0: Timeout) 8: SAMM_Mag_2 Status (1: OK, 0: Timeout) 9: SAMM_ToF_1 Status (1: OK, 0: Timeout) 10: SAMM_ToF_2 Status (1: OK, 0: Timeout) 11: TireTemp_FL Status (1: OK, 0: Timeout) 12: TireTemp_FR Status (1: OK, 0: Timeout) 13: TireTemp_RL Status (1: OK, 0: Timeout) 14: TireTemp_RR Status (1: OK, 0: Timeout) 15: Reserved";
-CM_ SG_ 2147615488 ecu_state "[Byte 2 / Bits 16-17] GLV States 0: GLV Off State, 1: GLV On State. See diagram in StateMachine. [Byte 2 / Bits 18-19] Precharge States 2: Precharge Engaged State 3: Precharge Complete State See diagram in StateMachine.h [Byte 2 / Bits 20-21] ECU States 4: Drive Active ECU State 5: TS Discharge ECU State 6-7: Reserved See diagram in StateMachine.h";
-CM_ SG_ 2147615488 Power_Level "Controls the AC current limits to each of the inverters Discrete Mapping, actual values TBD (16 possible values)";
-CM_ SG_ 2147615488 Torque_Map "The torque map selected; torque map is the mapping of the throttle to the torque sent to each motor";
-CM_ SG_ 2147615488 Max_Cell_Temp "the temperature of the hottest cell of the accumulator";
-CM_ SG_ 2147615488 Accumulator_State_of_Charge "% charged of the Accumulator";
-CM_ SG_ 2147615488 GLV_State_of_Charge "% charged of the Low Voltage Bat";
-CM_ SG_ 2147615744 Vehicle_Speed "Absolute value of speed";
-CM_ SG_ 2147615744 Tractive_System_Voltage "Output terminal voltage of accumulator";
-CM_ SG_ 2147615744 FR_Wheel_RPM "Wheel RPM";
-CM_ SG_ 2147615744 FL_Wheel_RPM "Wheel RPM";
-CM_ SG_ 2147616000 RR_Wheel_RPM "Wheel RPM";
-CM_ SG_ 2147616000 RL_Wheel_RPM "Wheel RPM";
-CM_ SG_ 2147615236 Timestamp "Time in millis";
-CM_ SG_ 2148335617 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2148336129 Timestamp "Time in millis";
-CM_ SG_ 2148336130 Timestamp "Time in millis";
-CM_ SG_ 2148341762 Fan_Speed "Fan RPM";
-CM_ SG_ 2148341762 Input_Voltage "0-22";
-CM_ SG_ 2148341762 Input_Current "0-10";
-CM_ SG_ 2148401153 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2148401665 Timestamp "Time in millis";
-CM_ SG_ 2148401666 Timestamp "Time in millis";
-CM_ SG_ 2148407298 Fan_Speed "Fan RPM";
-CM_ SG_ 2148407298 Input_Voltage "0-22";
-CM_ SG_ 2148407298 Input_Current "0-10";
-CM_ SG_ 2148466689 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2148467201 Timestamp "Time in millis";
-CM_ SG_ 2148467202 Timestamp "Time in millis";
-CM_ SG_ 2148472834 Fan_Speed "Fan RPM";
-CM_ SG_ 2148472834 Input_Voltage "0-22";
-CM_ SG_ 2148472834 Input_Current "0-10";
-CM_ SG_ 2148007937 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
-CM_ SG_ 2148008449 Timestamp "Time in millis";
-CM_ SG_ 2148008450 Timestamp "Time in millis";
-CM_ SG_ 2148012802 AC_current "0.01 * current, int16_t";
-CM_ SG_ 2148012802 DC_current "0.01 * current, int16_t";
-CM_ SG_ 2148012802 Motor_RPM "RPM, int16_t";
-CM_ SG_ 2148013058 U_MOSFET_temperature "Celsius + 40, uint8_t";
-CM_ SG_ 2148013058 V_MOSFET_temperature "Celsius + 40, uint8_t";
-CM_ SG_ 2148013058 W_MOSFET_temperature "Celsius + 40, uint8_t";
-CM_ SG_ 2148013314 Motor_temperature "Celsius + 40, uint8_t";
-CM_ SG_ 2148013314 fault_bits "TS above set max voltage, TS below set min voltage, Inverter over set max temp, Motor over set max temp, Mosfet or mosfet drive error, Encoder communication or calc error, CAN message error or timeout";
-CM_ SG_ 2147746305 Timestamp "Time in millis";
-CM_ SG_ 2147746306 Timestamp "Time in millis";
+CM_ SG_ 2149580801 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2149581313 Timestamp "Time in millis";
+CM_ SG_ 2149583363 Set_TS_Active "0: shutdown, 1: go TS Active/Precharge";
+CM_ SG_ 2149583619 Charge_Voltage "Sets the Target Charging voltage";
+CM_ SG_ 2149583619 Charge_Current "Sets the Target Charging Current";
+CM_ SG_ 2149583875 Minimium_Cell_Voltage "Sets the threshold for Minimum Cell Voltage before Shutdown";
+CM_ SG_ 2149583875 Max_Cell_Temperature "Sets the threshold for Max Cell Temperature before Shutdown";
+CM_ SG_ 2149581315 Timestamp "Time in millis";
+CM_ SG_ 2149586440 Max_AC_Current "Max AC Current";
+CM_ SG_ 2149586440 Max_DC_Current "Max DC Current";
+CM_ SG_ 2149586440 Absolute_Max_RPM_Limit "0: No limit      n :limited at n RPM";
+CM_ SG_ 2149586440 Motor_direction "Write 1 inverts direction";
+CM_ SG_ 2149586696 Set_AC_Current "Commanded AC Current";
+CM_ SG_ 2149586696 Set_DC_Current "Commanded DC Current";
+CM_ SG_ 2149586696 RPM_Limit "0: No limit      n :limited at n RPM";
+CM_ SG_ 2149586696 Field_weakening "Field weakening strength";
+CM_ SG_ 2149586696 Drive_enable "Write this to 1 every 100ms to enable inverter";
+CM_ SG_ 2149581320 Timestamp "Time in millis";
+CM_ SG_ 2149587213 Fan_Command "0-100 Percent";
+CM_ SG_ 2149581325 Timestamp "Time in millis";
+CM_ SG_ 2149587214 Fan_Command "0-100 Percent";
+CM_ SG_ 2149581326 Timestamp "Time in millis";
+CM_ SG_ 2149587215 Fan_Command "0-100 Percent";
+CM_ SG_ 2149581327 Timestamp "Time in millis";
+CM_ SG_ 2149587717 led_bits "[Byte 0 / Bits 0-7] 0: BMS LED command 1: IMD LED command 2: BSPD LED command 3-7: Reserved";
+CM_ SG_ 2149581317 Timestamp "Time in millis";
+CM_ SG_ 2149581568 status_flags "[Bytes 0-1 / Bits 0-15] 0: BCU Node Status (1: OK, 0: Timeout) 1: GR Inverter Status (1: OK, 0: Timeout) 2: Fan Controller 1 Status (1: OK, 0: Timeout) 3: Fan Controller 2 Status (1: OK, 0: Timeout) 4: Fan Controller 3 Status (1: OK, 0: Timeout) 5: Dash Panel Status (1: OK, 0: Timeout) 6: TCM Node Status (1: OK, 0: Timeout) 7: SAMM_Mag_1 Status (1: OK, 0: Timeout) 8: SAMM_Mag_2 Status (1: OK, 0: Timeout) 9: SAMM_ToF_1 Status (1: OK, 0: Timeout) 10: SAMM_ToF_2 Status (1: OK, 0: Timeout) 11: TireTemp_FL Status (1: OK, 0: Timeout) 12: TireTemp_FR Status (1: OK, 0: Timeout) 13: TireTemp_RL Status (1: OK, 0: Timeout) 14: TireTemp_RR Status (1: OK, 0: Timeout) 15: Reserved";
+CM_ SG_ 2149581568 ecu_state "[Byte 2 / Bits 16-17] GLV States 0: GLV Off State, 1: GLV On State. See diagram in StateMachine. [Byte 2 / Bits 18-19] Precharge States 2: Precharge Engaged State 3: Precharge Complete State See diagram in StateMachine.h [Byte 2 / Bits 20-21] ECU States 4: Drive Active ECU State 5: TS Discharge ECU State 6-7: Reserved See diagram in StateMachine.h";
+CM_ SG_ 2149581568 Power_Level "Controls the AC current limits to each of the inverters Discrete Mapping, actual values TBD (16 possible values)";
+CM_ SG_ 2149581568 Torque_Map "The torque map selected; torque map is the mapping of the throttle to the torque sent to each motor";
+CM_ SG_ 2149581568 Max_Cell_Temp "the temperature of the hottest cell of the accumulator";
+CM_ SG_ 2149581568 Accumulator_State_of_Charge "% charged of the Accumulator";
+CM_ SG_ 2149581568 GLV_State_of_Charge "% charged of the Low Voltage Bat";
+CM_ SG_ 2149581824 Vehicle_Speed "Absolute value of speed";
+CM_ SG_ 2149581824 Tractive_System_Voltage "Output terminal voltage of accumulator";
+CM_ SG_ 2149581824 FR_Wheel_RPM "Wheel RPM";
+CM_ SG_ 2149581824 FL_Wheel_RPM "Wheel RPM";
+CM_ SG_ 2149582080 RR_Wheel_RPM "Wheel RPM";
+CM_ SG_ 2149582080 RL_Wheel_RPM "Wheel RPM";
+CM_ SG_ 2149581316 Timestamp "Time in millis";
+CM_ SG_ 2161115137 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2161115649 Timestamp "Time in millis";
+CM_ SG_ 2161115650 Timestamp "Time in millis";
+CM_ SG_ 2161121282 Fan_Speed "Fan RPM";
+CM_ SG_ 2161121282 Input_Voltage "0-22";
+CM_ SG_ 2161121282 Input_Current "0-10";
+CM_ SG_ 2162163713 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2162164225 Timestamp "Time in millis";
+CM_ SG_ 2162164226 Timestamp "Time in millis";
+CM_ SG_ 2162169858 Fan_Speed "Fan RPM";
+CM_ SG_ 2162169858 Input_Voltage "0-22";
+CM_ SG_ 2162169858 Input_Current "0-10";
+CM_ SG_ 2163212289 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2163212801 Timestamp "Time in millis";
+CM_ SG_ 2163212802 Timestamp "Time in millis";
+CM_ SG_ 2163218434 Fan_Speed "Fan RPM";
+CM_ SG_ 2163218434 Input_Voltage "0-22";
+CM_ SG_ 2163218434 Input_Current "0-10";
+CM_ SG_ 2155872257 Debug "Essentially a print statement up to 8 bytes long that whichever targeted can parse";
+CM_ SG_ 2155872769 Timestamp "Time in millis";
+CM_ SG_ 2155872770 Timestamp "Time in millis";
+CM_ SG_ 2155877122 AC_current "0.01 * current, int16_t";
+CM_ SG_ 2155877122 DC_current "0.01 * current, int16_t";
+CM_ SG_ 2155877122 Motor_RPM "RPM, int16_t";
+CM_ SG_ 2155877378 U_MOSFET_temperature "Celsius + 40, uint8_t";
+CM_ SG_ 2155877378 V_MOSFET_temperature "Celsius + 40, uint8_t";
+CM_ SG_ 2155877378 W_MOSFET_temperature "Celsius + 40, uint8_t";
+CM_ SG_ 2155877634 Motor_temperature "Celsius + 40, uint8_t";
+CM_ SG_ 2155877634 fault_bits "TS above set max voltage, TS below set min voltage, Inverter over set max temp, Motor over set max temp, Mosfet or mosfet drive error, Encoder communication or calc error, CAN message error or timeout";
+CM_ SG_ 2151678465 Timestamp "Time in millis";
+CM_ SG_ 2151678466 Timestamp "Time in millis";

--- a/Autogen/CAN/Src/DBCparser.pl
+++ b/Autogen/CAN/Src/DBCparser.pl
@@ -26,7 +26,7 @@ use Readonly;
 # --- Constants ---
 Readonly::Scalar my $BITS_PER_BYTE         => 8;
 Readonly::Scalar my $SHIFT_MSG             => 8;
-Readonly::Scalar my $SHIFT_SENDER          => 16;
+Readonly::Scalar my $SHIFT_SENDER          => 20;
 Readonly::Scalar my $EXTENDED_ID_THRESHOLD => 0x7FF;
 Readonly::Scalar my $EXTENDED_ID_MASK      => 2_147_483_648;
 Readonly::Scalar my $EMPTY_STR             => q{};


### PR DESCRIPTION
# DBC Identifier Fix

## Problem and Scope
DBC message identifiers are incorrect

## Description
Cause by an incorrect bit shifting (`16` instead of `20`) for the sender node ID

## Gotchas and Limitations
May be a larger problem but probably not

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Select DBC message identifier fields are correct

## Larger Impact
LV testing

## Additional Context and Ticket
Found by @an0tv 