### PR TITLE
Soft Remove STM32 Dash Panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ include("${lib_path}/FancyLayers-RENAME/NeoPixel/neopixel.cmake")
 # Projects
 add_gr_project(STM32G474xE ECU)
 add_gr_project(STM32G474xE CCU)
-add_gr_project(STM32G474xE DashPanel)
+# add_gr_project(STM32G474xE DashPanel)
 add_gr_project(STM32G474xE AnalogCalibration)
 add_gr_project(STM32G474xE CANine)
 add_gr_project(STM32G431x8 TireTemp)

--- a/DashPanel/CMakeLists.txt
+++ b/DashPanel/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
+message(FATAL_ERROR "Dash panel is no longer going to be used, it has been replaced by GR24 Arduino-based dash panel for the GR26 year")
+
 # Setup compiler settings
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/DashPanel/CMakeLists.txt
+++ b/DashPanel/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.25)
 
-message(FATAL_ERROR "Dash panel is no longer going to be used, it has been replaced by GR24 Arduino-based dash panel for the GR26 year")
+message(
+	FATAL_ERROR
+	"Dash panel is no longer going to be used, it has been replaced by GR24 Arduino-based dash panel for the GR26 year"
+)
 
 # Setup compiler settings
 set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
# `DELETE FROM Boards WHERE name = "DashPanel"`

## Problem and Scope
GR26 Dash Panel is now based on the GR24 Arduino-based dash panel, involving no STM32 code

## Description
Soft remove dash panel with comments and fatal error warning message

## Gotchas and Limitations
Can be added back trivially, but underlying CAN has changed around it so it should be deleted eventually

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Does not build `DashPanel` on `make all`

## Larger Impact
Allows moving CAN forward without compile errors

## Additional Context and Ticket
Replaced by [`GR24_Dash_Panel` -> `GR26_DASH`](https://github.com/Gaucho-Racing/GR24_Dash_Panel/tree/main/GR26_DASH)