### PR TITLE
Fix CAN Filter on ECU and CCU

### DIFF
--- a/CCU/Application/Src/CANDler.c
+++ b/CCU/Application/Src/CANDler.c
@@ -82,8 +82,8 @@ void CAN_Configure(void)
 	canCfg.hal_fdcan_init.DataSyncJumpWidth = 16;
 	canCfg.hal_fdcan_init.DataTimeSeg1 = 15; // Updated for 170MHz: (1+15+5)*8 = 168 ticks -> ~5 Mbps
 	canCfg.hal_fdcan_init.DataTimeSeg2 = 5;
-	canCfg.hal_fdcan_init.StdFiltersNbr = 1;
-	canCfg.hal_fdcan_init.ExtFiltersNbr = 0;
+	canCfg.hal_fdcan_init.StdFiltersNbr = 0;
+	canCfg.hal_fdcan_init.ExtFiltersNbr = 2;
 
 	canCfg.rx_callback = Read_CAN;
 	canCfg.rx_interrupt_priority = 15; // TODO: Maybe make these not hardcoded
@@ -134,23 +134,24 @@ void CAN_Configure(void)
 
 	primary_can = can_init(&canCfg); // FIXME: make type *CANHANDLE, look at can.h
 
-	// Filter 1 Definitions
-	FDCAN_FilterTypeDef fdcan1_filter;
+	FDCAN_FilterTypeDef fdcan1_filter_ccu = {0};
+	fdcan1_filter_ccu.IdType = FDCAN_EXTENDED_ID;
+	fdcan1_filter_ccu.FilterIndex = 0;
+	fdcan1_filter_ccu.FilterType = FDCAN_FILTER_MASK;
+	fdcan1_filter_ccu.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan1_filter_ccu.FilterID1 = GRCAN_CCU & 0xFF;
+	fdcan1_filter_ccu.FilterID2 = 0x000000FF;
 
-	fdcan1_filter.IdType = FDCAN_EXTENDED_ID;
-	fdcan1_filter.FilterIndex = 0;
-	fdcan1_filter.FilterType = FDCAN_FILTER_MASK;
-	fdcan1_filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan1_filter.FilterID1 = LOCAL_GR_ID; // filter messages with ECU destination
-	fdcan1_filter.FilterID2 = 0x00000FF;
+	FDCAN_FilterTypeDef fdcan1_filter_all = {0};
+	fdcan1_filter_all.IdType = FDCAN_EXTENDED_ID;
+	fdcan1_filter_all.FilterIndex = 1;
+	fdcan1_filter_all.FilterType = FDCAN_FILTER_MASK;
+	fdcan1_filter_all.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan1_filter_all.FilterID1 = GRCAN_ALL & 0xFF;
+	fdcan1_filter_all.FilterID2 = 0x000000FF;
 
-	fdcan1_filter.FilterIndex = 1;
-	fdcan1_filter.FilterID1 = 0xFF; // filter messages for all targets
-	HAL_FDCAN_ConfigFilter(primary_can->hal_fdcanP, &fdcan1_filter);
-
-	// CAN2 ======================================================
-
-	// accept unmatched standard and extended frames into RXFIFO0 - default behaviour
+	can_add_filter(primary_can, &fdcan1_filter_ccu);
+	can_add_filter(primary_can, &fdcan1_filter_all);
 
 	can_start(primary_can);
 }
@@ -159,7 +160,7 @@ void SendPrechargeStatus(CCU_StateData *state_data)
 {
 
 	FDCANTxMessage msg;
-	msg.tx_header.Identifier = ((0xFF & LOCAL_GR_ID) << 20) | ((0xFFF & GRCAN_BCU_PRECHARGE) << 8) | (0xFF & GRCAN_BCU);
+	msg.tx_header.Identifier = ((0xFF & GRCAN_CCU) << 20) | ((0xFFF & GRCAN_BCU_PRECHARGE) << 8) | (0xFF & GRCAN_BCU);
 	msg.tx_header.IdType = FDCAN_EXTENDED_ID;
 	msg.tx_header.TxFrameType = FDCAN_DATA_FRAME;
 	msg.tx_header.ErrorStateIndicator = FDCAN_ESI_ACTIVE;

--- a/CCU/Core/Inc/main.h
+++ b/CCU/Core/Inc/main.h
@@ -108,7 +108,7 @@ void Error_Handler(void);
 #define SOFTWARE_OK_CONTROL_GPIO_Port GPIOB
 
 /* USER CODE BEGIN Private defines */
-#define LOCAL_GR_ID GRCAN_CCU
+
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus

--- a/ECU/Application/Src/CANutils.c
+++ b/ECU/Application/Src/CANutils.c
@@ -21,7 +21,7 @@ void ECU_CAN_Send(GRCAN_BUS_ID bus, GRCAN_NODE_ID destNode, GRCAN_MSG_ID message
 		LOGOMATIC("Tried to send more than 64 bytes over CAN");
 	}
 
-	uint32_t ID = ((0xFF & LOCAL_GR_ID) << 20) | ((0xFFF & messageID) << 8) | (0xFF & destNode);
+	uint32_t ID = ((0xFF & GRCAN_ECU) << 20) | ((0xFFF & messageID) << 8) | (0xFF & destNode);
 
 	FDCAN_TxHeaderTypeDef header = {
 	    .Identifier = ID,

--- a/ECU/Core/Inc/main.h
+++ b/ECU/Core/Inc/main.h
@@ -58,7 +58,7 @@ extern "C" {
 
 /* Exported macro ------------------------------------------------------------*/
 /* USER CODE BEGIN EM */
-#define LOCAL_GR_ID GRCAN_ECU
+
 /* USER CODE END EM */
 
 /* Exported functions prototypes ---------------------------------------------*/

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -234,8 +234,8 @@ void CAN_Configure()
 	canCfg.hal_fdcan_init.DataSyncJumpWidth = 16;
 	canCfg.hal_fdcan_init.DataTimeSeg1 = 12; // Updated for 170MHz: 170 MHz/((1+12+4)*2) = 5 Mbps
 	canCfg.hal_fdcan_init.DataTimeSeg2 = 4;
-	canCfg.hal_fdcan_init.StdFiltersNbr = 1;
-	canCfg.hal_fdcan_init.ExtFiltersNbr = 0;
+	canCfg.hal_fdcan_init.StdFiltersNbr = 0;
+	canCfg.hal_fdcan_init.ExtFiltersNbr = 2; // we'll add two extended filters: LOCAL_GR_ID and GRCAN_ALL
 
 	canCfg.rx_callback = NULL;
 	canCfg.rx_interrupt_priority = 15; // TODO: Maybe make these not hardcoded
@@ -284,21 +284,26 @@ void CAN_Configure()
 	// RX Callback CAN1
 	canCfg.rx_callback = CAN1_rx_callback; // TODO: Make sure the wrapper for this is defined correctly
 
+	FDCAN_FilterTypeDef fdcan1_filter0 = {0};
+	fdcan1_filter0.IdType = FDCAN_EXTENDED_ID;
+	fdcan1_filter0.FilterIndex = 0;
+	fdcan1_filter0.FilterType = FDCAN_FILTER_MASK;
+	fdcan1_filter0.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan1_filter0.FilterID1 = GRCAN_ECU & 0xFF;
+	fdcan1_filter0.FilterID2 = 0x000000FF;
+
+	FDCAN_FilterTypeDef fdcan1_filter1 = {0};
+	fdcan1_filter1.IdType = FDCAN_EXTENDED_ID;
+	fdcan1_filter1.FilterIndex = 1;
+	fdcan1_filter1.FilterType = FDCAN_FILTER_MASK;
+	fdcan1_filter1.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan1_filter1.FilterID1 = GRCAN_ALL & 0xFF;
+	fdcan1_filter1.FilterID2 = 0x000000FF;
+
 	primary_can = can_init(&canCfg);
 
-	// Filter 1 Definitions
-	FDCAN_FilterTypeDef fdcan1_filter;
-
-	fdcan1_filter.IdType = FDCAN_EXTENDED_ID;
-	fdcan1_filter.FilterIndex = 0;
-	fdcan1_filter.FilterType = FDCAN_FILTER_MASK;
-	fdcan1_filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan1_filter.FilterID1 = LOCAL_GR_ID; // filter messages with ECU destination
-	fdcan1_filter.FilterID2 = 0x00000FF;
-
-	fdcan1_filter.FilterIndex = 1;
-	fdcan1_filter.FilterID1 = 0xFF; // filter messages for all targets
-	HAL_FDCAN_ConfigFilter(primary_can->hal_fdcanP, &fdcan1_filter);
+	can_add_filter(primary_can, &fdcan1_filter0);
+	can_add_filter(primary_can, &fdcan1_filter1);
 
 	// CAN2 ======================================================
 	canCfg.fdcan_instance = FDCAN2;
@@ -313,22 +318,26 @@ void CAN_Configure()
 	// RX Callback CAN2
 	canCfg.rx_callback = CAN2_rx_callback; // TODO: Make sure the wrapper for this is defined correctly
 
-	// Filter definitions
-	FDCAN_FilterTypeDef fdcan2_filter;
+	FDCAN_FilterTypeDef fdcan2_filter0 = {0};
+	fdcan2_filter0.IdType = FDCAN_EXTENDED_ID;
+	fdcan2_filter0.FilterIndex = 0;
+	fdcan2_filter0.FilterType = FDCAN_FILTER_MASK;
+	fdcan2_filter0.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan2_filter0.FilterID1 = GRCAN_ECU & 0xFF;
+	fdcan2_filter0.FilterID2 = 0x000000FF;
 
-	fdcan2_filter.IdType = FDCAN_EXTENDED_ID;
-	fdcan2_filter.FilterIndex = 0;
-	fdcan2_filter.FilterType = FDCAN_FILTER_MASK;
-	fdcan2_filter.FilterConfig = FDCAN_FILTER_TO_RXFIFO0; // TODO: check if this works during test, RXFifos may not be indpeendent (but it sur)
-	fdcan2_filter.FilterID2 = 0x00000FF;
-
-	fdcan2_filter.FilterIndex = 1;
-	fdcan2_filter.FilterID1 = 0xFF; // filter messages for all targets
+	FDCAN_FilterTypeDef fdcan2_filter1 = {0};
+	fdcan2_filter1.IdType = FDCAN_EXTENDED_ID;
+	fdcan2_filter1.FilterIndex = 1;
+	fdcan2_filter1.FilterType = FDCAN_FILTER_MASK;
+	fdcan2_filter1.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan2_filter1.FilterID1 = GRCAN_ALL & 0xFF;
+	fdcan2_filter1.FilterID2 = 0x000000FF;
 
 	data_can = can_init(&canCfg);
 
-	// accept unmatched standard and extended frames into RXFIFO0 - default behaviour
-	HAL_FDCAN_ConfigFilter(data_can->hal_fdcanP, &fdcan2_filter);
+	can_add_filter(data_can, &fdcan2_filter0);
+	can_add_filter(data_can, &fdcan2_filter1);
 
 	can_start(primary_can);
 	can_start(data_can);

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -236,7 +236,7 @@ void CAN_Configure()
 	canCfg.hal_fdcan_init.DataTimeSeg2 = 4;
 	canCfg.hal_fdcan_init.StdFiltersNbr = 0;
 	canCfg.hal_fdcan_init.ExtFiltersNbr = 2;
-	
+
 	canCfg.rx_callback = NULL;
 	canCfg.rx_interrupt_priority = 15; // TODO: Maybe make these not hardcoded
 	canCfg.tx_interrupt_priority = 15;

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -235,8 +235,8 @@ void CAN_Configure()
 	canCfg.hal_fdcan_init.DataTimeSeg1 = 12; // Updated for 170MHz: 170 MHz/((1+12+4)*2) = 5 Mbps
 	canCfg.hal_fdcan_init.DataTimeSeg2 = 4;
 	canCfg.hal_fdcan_init.StdFiltersNbr = 0;
-	canCfg.hal_fdcan_init.ExtFiltersNbr = 2; // we'll add two extended filters: LOCAL_GR_ID and GRCAN_ALL
-
+	canCfg.hal_fdcan_init.ExtFiltersNbr = 2;
+	
 	canCfg.rx_callback = NULL;
 	canCfg.rx_interrupt_priority = 15; // TODO: Maybe make these not hardcoded
 	canCfg.tx_interrupt_priority = 15;
@@ -284,26 +284,26 @@ void CAN_Configure()
 	// RX Callback CAN1
 	canCfg.rx_callback = CAN1_rx_callback; // TODO: Make sure the wrapper for this is defined correctly
 
-	FDCAN_FilterTypeDef fdcan1_filter0 = {0};
-	fdcan1_filter0.IdType = FDCAN_EXTENDED_ID;
-	fdcan1_filter0.FilterIndex = 0;
-	fdcan1_filter0.FilterType = FDCAN_FILTER_MASK;
-	fdcan1_filter0.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan1_filter0.FilterID1 = GRCAN_ECU & 0xFF;
-	fdcan1_filter0.FilterID2 = 0x000000FF;
+	FDCAN_FilterTypeDef fdcan_primary_filter_ecu = {0};
+	fdcan_primary_filter_ecu.IdType = FDCAN_EXTENDED_ID;
+	fdcan_primary_filter_ecu.FilterIndex = 0;
+	fdcan_primary_filter_ecu.FilterType = FDCAN_FILTER_MASK;
+	fdcan_primary_filter_ecu.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan_primary_filter_ecu.FilterID1 = GRCAN_ECU & 0xFF;
+	fdcan_primary_filter_ecu.FilterID2 = 0x000000FF;
 
-	FDCAN_FilterTypeDef fdcan1_filter1 = {0};
-	fdcan1_filter1.IdType = FDCAN_EXTENDED_ID;
-	fdcan1_filter1.FilterIndex = 1;
-	fdcan1_filter1.FilterType = FDCAN_FILTER_MASK;
-	fdcan1_filter1.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan1_filter1.FilterID1 = GRCAN_ALL & 0xFF;
-	fdcan1_filter1.FilterID2 = 0x000000FF;
+	FDCAN_FilterTypeDef fdcan_primary_filter_all = {0};
+	fdcan_primary_filter_all.IdType = FDCAN_EXTENDED_ID;
+	fdcan_primary_filter_all.FilterIndex = 1;
+	fdcan_primary_filter_all.FilterType = FDCAN_FILTER_MASK;
+	fdcan_primary_filter_all.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan_primary_filter_all.FilterID1 = GRCAN_ALL & 0xFF;
+	fdcan_primary_filter_all.FilterID2 = 0x000000FF;
 
 	primary_can = can_init(&canCfg);
 
-	can_add_filter(primary_can, &fdcan1_filter0);
-	can_add_filter(primary_can, &fdcan1_filter1);
+	can_add_filter(primary_can, &fdcan_primary_filter_ecu);
+	can_add_filter(primary_can, &fdcan_primary_filter_all);
 
 	// CAN2 ======================================================
 	canCfg.fdcan_instance = FDCAN2;
@@ -318,26 +318,26 @@ void CAN_Configure()
 	// RX Callback CAN2
 	canCfg.rx_callback = CAN2_rx_callback; // TODO: Make sure the wrapper for this is defined correctly
 
-	FDCAN_FilterTypeDef fdcan2_filter0 = {0};
-	fdcan2_filter0.IdType = FDCAN_EXTENDED_ID;
-	fdcan2_filter0.FilterIndex = 0;
-	fdcan2_filter0.FilterType = FDCAN_FILTER_MASK;
-	fdcan2_filter0.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan2_filter0.FilterID1 = GRCAN_ECU & 0xFF;
-	fdcan2_filter0.FilterID2 = 0x000000FF;
+	FDCAN_FilterTypeDef fdcan_data_filter_ecu = {0};
+	fdcan_data_filter_ecu.IdType = FDCAN_EXTENDED_ID;
+	fdcan_data_filter_ecu.FilterIndex = 0;
+	fdcan_data_filter_ecu.FilterType = FDCAN_FILTER_MASK;
+	fdcan_data_filter_ecu.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan_data_filter_ecu.FilterID1 = GRCAN_ECU & 0xFF;
+	fdcan_data_filter_ecu.FilterID2 = 0x000000FF;
 
-	FDCAN_FilterTypeDef fdcan2_filter1 = {0};
-	fdcan2_filter1.IdType = FDCAN_EXTENDED_ID;
-	fdcan2_filter1.FilterIndex = 1;
-	fdcan2_filter1.FilterType = FDCAN_FILTER_MASK;
-	fdcan2_filter1.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
-	fdcan2_filter1.FilterID1 = GRCAN_ALL & 0xFF;
-	fdcan2_filter1.FilterID2 = 0x000000FF;
+	FDCAN_FilterTypeDef fdcan_data_filter_all = {0};
+	fdcan_data_filter_all.IdType = FDCAN_EXTENDED_ID;
+	fdcan_data_filter_all.FilterIndex = 1;
+	fdcan_data_filter_all.FilterType = FDCAN_FILTER_MASK;
+	fdcan_data_filter_all.FilterConfig = FDCAN_FILTER_TO_RXFIFO0;
+	fdcan_data_filter_all.FilterID1 = GRCAN_ALL & 0xFF;
+	fdcan_data_filter_all.FilterID2 = 0x000000FF;
 
 	data_can = can_init(&canCfg);
 
-	can_add_filter(data_can, &fdcan2_filter0);
-	can_add_filter(data_can, &fdcan2_filter1);
+	can_add_filter(data_can, &fdcan_data_filter_ecu);
+	can_add_filter(data_can, &fdcan_data_filter_all);
 
 	can_start(primary_can);
 	can_start(data_can);

--- a/ECU/Test/Inc/main.h
+++ b/ECU/Test/Inc/main.h
@@ -1,2 +1,1 @@
 #include "GRCAN_NODE_ID.h"
-#define LOCAL_GR_ID GRCAN_ECU


### PR DESCRIPTION
# CAN Filter Fix

## Problem and Scope
Setup for simple non-extended ID with basic filter

## Description
Replaced with two extended ID filters on `GRCAN_ALL` and `GRCAN_(E|C)CU`

## Gotchas and Limitations
Needs testing of course, getting it into `LV-test` will be helpful

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Hardware tests pending

## Larger Impact
Less interrupts for things we do not care about (but honestly these nodes get most things anyway)

## Additional Context and Ticket
Found while investigating #350