### PR TITLE
Configure Logomatic Enablment At `CMakePresets.json` Level

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,35 +20,40 @@
 			"cacheVariables": {
 				"CMAKE_BUILD_TYPE": "Debug",
 				"TARGET_TYPE": "Host",
-				"CMAKE_PRESET_NAME": "${presetName}"
+				"CMAKE_PRESET_NAME": "${presetName}",
+				"CMAKE_LOGOMATIC_ENABLED": "ON"
 			}
 		},
 		{
 			"name": "Debug",
 			"inherits": "stm",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Debug"
+				"CMAKE_BUILD_TYPE": "Debug",
+				"CMAKE_LOGOMATIC_ENABLED": "ON"
 			}
 		},
 		{
 			"name": "RelWithDebInfo",
 			"inherits": "stm",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
+				"CMAKE_LOGOMATIC_ENABLED": "ON"
 			}
 		},
 		{
 			"name": "Release",
 			"inherits": "stm",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Release"
+				"CMAKE_BUILD_TYPE": "Release",
+				"CMAKE_LOGOMATIC_ENABLED": "OFF"
 			}
 		},
 		{
 			"name": "MinSizeRel",
 			"inherits": "stm",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "MinSizeRel"
+				"CMAKE_BUILD_TYPE": "MinSizeRel",
+				"CMAKE_LOGOMATIC_ENABLED": "OFF"
 			}
 		}
 	],

--- a/Lib/Utils/Logomatic/logomatic.cmake
+++ b/Lib/Utils/Logomatic/logomatic.cmake
@@ -14,15 +14,7 @@ target_sources(
 
 target_link_libraries(LOGOMATIC_LIB INTERFACE GLOBALSHARE_LIB)
 
-if(
-	CMAKE_PRESET_NAME
-		STREQUAL
-		"Debug"
-	OR
-		CMAKE_PRESET_NAME
-			STREQUAL
-			"RelWithDebInfo"
-)
+if(CMAKE_LOGOMATIC_ENABLED)
 	target_compile_definitions(LOGOMATIC_LIB INTERFACE LOGOMATIC_ENABLED)
 	target_compile_options(
 		LOGOMATIC_LIB

--- a/Lib/Utils/Logomatic/logomatic.cmake
+++ b/Lib/Utils/Logomatic/logomatic.cmake
@@ -20,6 +20,7 @@ endif()
 
 # Main compilation flag to enable logomatic
 if(CMAKE_LOGOMATIC_ENABLED)
+	message(STATUS "Logomatic enabled")
 	target_compile_definitions(LOGOMATIC_LIB INTERFACE LOGOMATIC_ENABLED)
 endif()
 

--- a/Lib/Utils/Logomatic/logomatic.cmake
+++ b/Lib/Utils/Logomatic/logomatic.cmake
@@ -31,8 +31,6 @@ if(CMAKE_LOGOMATIC_ENABLED)
 endif()
 
 if(CMAKE_PRESET_NAME STREQUAL "HOOTLTest")
-	target_compile_definitions(LOGOMATIC_LIB INTERFACE LOGOMATIC_ENABLED)
-
 	add_executable(logomatic_simple)
 	target_sources(
 		logomatic_simple

--- a/Lib/Utils/Logomatic/logomatic.cmake
+++ b/Lib/Utils/Logomatic/logomatic.cmake
@@ -1,33 +1,21 @@
 add_library(LOGOMATIC_LIB INTERFACE)
 
+# Include directories and source files for the logomatic library
 target_include_directories(
 	LOGOMATIC_LIB
 	INTERFACE
 		${CMAKE_CURRENT_LIST_DIR}/Inc
 )
-
 target_sources(
 	LOGOMATIC_LIB
 	INTERFACE
 		${CMAKE_CURRENT_LIST_DIR}/Src/Logomatic.c
 )
-
 target_link_libraries(LOGOMATIC_LIB INTERFACE GLOBALSHARE_LIB)
 
+# Main compilation flag to enable logomatic
 if(CMAKE_LOGOMATIC_ENABLED)
 	target_compile_definitions(LOGOMATIC_LIB INTERFACE LOGOMATIC_ENABLED)
-	target_compile_options(
-		LOGOMATIC_LIB
-		INTERFACE
-			-u
-			_printf_float
-	)
-	target_link_options(
-		LOGOMATIC_LIB
-		INTERFACE
-			-u
-			_printf_float
-	)
 endif()
 
 if(CMAKE_PRESET_NAME STREQUAL "HOOTLTest")
@@ -58,4 +46,18 @@ if(CMAKE_PRESET_NAME STREQUAL "HOOTLTest")
 	)
 	target_link_libraries(logomatic_float PRIVATE LOGOMATIC_LIB)
 	add_test(logomatic_float_test logomatic_float)
+else()
+	# Add floating point support for printf, which goes unused on MacOS hootl builds and throws a warning
+	target_compile_options(
+		LOGOMATIC_LIB
+		INTERFACE
+			-u
+			_printf_float
+	)
+	target_link_options(
+		LOGOMATIC_LIB
+		INTERFACE
+			-u
+			_printf_float
+	)
 endif()

--- a/Lib/Utils/Logomatic/logomatic.cmake
+++ b/Lib/Utils/Logomatic/logomatic.cmake
@@ -13,6 +13,11 @@ target_sources(
 )
 target_link_libraries(LOGOMATIC_LIB INTERFACE GLOBALSHARE_LIB)
 
+# Default logomatic to be disabled
+if(NOT DEFINED CMAKE_LOGOMATIC_ENABLED)
+	set(CMAKE_LOGOMATIC_ENABLED OFF)
+endif()
+
 # Main compilation flag to enable logomatic
 if(CMAKE_LOGOMATIC_ENABLED)
 	target_compile_definitions(LOGOMATIC_LIB INTERFACE LOGOMATIC_ENABLED)


### PR DESCRIPTION
# More Variable Logomatic

## Problem and Scope
@kzwicker wants more control off of when logomatic is enabled or not

## Description
Logomatic enablment variable

## Gotchas and Limitations
Debug with TCM may have other issues (eg ITM)

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Test all presets on CCU and HOOTL

## Larger Impact
Now can be controlled via `CMakeUserPresets.json` or by just editing the `CMakePresets.json`

## Additional Context and Ticket
None