### PR TITLE
Auto-Format Only On PRs Ready For Review

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -3,6 +3,7 @@ run-name: Auto Format - ${{ github.ref_name }}
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   clang:
+    if: ${{ !github.event.pull_request.draft }}
     name: Clang
     runs-on: ubuntu-latest
     permissions:
@@ -44,6 +45,7 @@ jobs:
           fetch: 'false'
 
   cmake:
+    if: ${{ !github.event.pull_request.draft }}
     name: CMake
     runs-on: ubuntu-slim
     permissions:
@@ -76,6 +78,7 @@ jobs:
           fetch: 'false'
 
   json:
+    if: ${{ !github.event.pull_request.draft }}
     name: Json
     runs-on: ubuntu-slim
     permissions:
@@ -104,6 +107,7 @@ jobs:
           fetch: 'false'
 
   perl:
+    if: ${{ !github.event.pull_request.draft }}
     name: Perl
     runs-on: ubuntu-slim
     permissions:
@@ -137,6 +141,7 @@ jobs:
           fetch: 'false'
 
   asm:
+    if: ${{ !github.event.pull_request.draft }}
     name: Assembly
     runs-on: ubuntu-slim
     permissions:
@@ -176,6 +181,7 @@ jobs:
           fetch: 'false'
 
   web:
+    if: ${{ !github.event.pull_request.draft }}
     name: Web
     runs-on: ubuntu-slim
     permissions:
@@ -216,11 +222,11 @@ jobs:
           fetch: 'false'
 
   all:
+    if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All Auto Formatters
     needs: [ clang, cmake, json, perl, asm, web ]
     runs-on: ubuntu-slim
     permissions: { }
-    if: always()
     steps:
       - name: Fail Auto Format
         if: >

--- a/CCU/Core/Src/main.c
+++ b/CCU/Core/Src/main.c
@@ -163,7 +163,7 @@ void SystemClock_Config(void)
 	while (LL_RCC_HSE_IsReady() != 1) {}
 
 	LL_RCC_HSE_EnableCSS();
-						LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);
+	LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);
 	LL_RCC_PLL_EnableDomain_SYS();
 	LL_RCC_PLL_Enable();
 	/* Wait till PLL is ready */

--- a/CCU/Core/Src/main.c
+++ b/CCU/Core/Src/main.c
@@ -170,7 +170,7 @@ void SystemClock_Config(void)
 	while (LL_RCC_PLL_IsReady() != 1) {}
 
 	LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
-	LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
+									LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
 	/* Wait till System clock is ready */
 	while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {}
 

--- a/CCU/Core/Src/main.c
+++ b/CCU/Core/Src/main.c
@@ -163,7 +163,7 @@ void SystemClock_Config(void)
 	while (LL_RCC_HSE_IsReady() != 1) {}
 
 	LL_RCC_HSE_EnableCSS();
-	LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);
+						LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);
 	LL_RCC_PLL_EnableDomain_SYS();
 	LL_RCC_PLL_Enable();
 	/* Wait till PLL is ready */

--- a/CCU/Core/Src/main.c
+++ b/CCU/Core/Src/main.c
@@ -170,7 +170,7 @@ void SystemClock_Config(void)
 	while (LL_RCC_PLL_IsReady() != 1) {}
 
 	LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
-									LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
+	LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
 	/* Wait till System clock is ready */
 	while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {}
 


### PR DESCRIPTION
# Limit Auto-Format

## Problem and Scope
Burning trees with needless auto-format runs, and people do not like getting surprise commits

## Description
Only run auto format on non-draft

## Gotchas and Limitations
Still required for testing

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
- Runs formatters as soon as marked ready for review
- Runs formatters on new pushes while ready for review
- Skips formatters on new pushes while marked as a draft

## Larger Impact
Convenience

## Additional Context and Ticket
Resolves #468