### PR TITLE
Limit CI/CD Runs Further While Marked As Draft

### DIFF
--- a/.github/workflows/AutoFormat.yml
+++ b/.github/workflows/AutoFormat.yml
@@ -36,14 +36,14 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic Clang-Format: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic Clang-Format: Standardized formatting automatically"
+          fetch: "false"
 
   cmake:
     if: ${{ !github.event.pull_request.draft }}
@@ -62,21 +62,21 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.x'
+          python-version: "3.x"
           pip-install: gersemi
 
       - name: Format CMake Files
         run: gersemi --in-place ${{ github.workspace }}
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic CMake Format: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic CMake Format: Standardized formatting automatically"
+          fetch: "false"
 
   json:
     if: ${{ !github.event.pull_request.draft }}
@@ -98,14 +98,14 @@ jobs:
           git ls-files '*.json' | xargs -r -I{} sh -c 'jq --tab . {} > {}.tmp && mv {}.tmp {}'
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic Json Format: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic Json Format: Standardized formatting automatically"
+          fetch: "false"
 
   perl:
     if: ${{ !github.event.pull_request.draft }}
@@ -122,9 +122,9 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6  # v1.41.1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1.41.1
         with:
-          install-modules: 'Perl::Tidy'
+          install-modules: "Perl::Tidy"
 
       - name: Format Perl Files
         run: |
@@ -132,14 +132,14 @@ jobs:
           git ls-files '*.pl' '*.pm' | xargs perltidy -b -bext='/'
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic Perl Tidy: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic Perl Tidy: Standardized formatting automatically"
+          fetch: "false"
 
   asm:
     if: ${{ !github.event.pull_request.draft }}
@@ -158,7 +158,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version: "stable"
           cache: false
 
       - name: Install asmfmt
@@ -172,14 +172,14 @@ jobs:
           git ls-files '*.s' '*.asm' | xargs -r asmfmt -w -e
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic Assembly Format: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic Assembly Format: Standardized formatting automatically"
+          fetch: "false"
 
   web:
     if: ${{ !github.event.pull_request.draft }}
@@ -213,21 +213,21 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic Web Format: Standardized formatting automatically'
-          fetch: 'false'
+          message: "Automatic Web Format: Standardized formatting automatically"
+          fetch: "false"
 
   all:
     if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All Auto Formatters
-    needs: [ clang, cmake, json, perl, asm, web ]
+    needs: [clang, cmake, json, perl, asm, web]
     runs-on: ubuntu-slim
-    permissions: { }
+    permissions: {}
     steps:
       - name: Fail Auto Format
         if: >

--- a/.github/workflows/Autogen.yml
+++ b/.github/workflows/Autogen.yml
@@ -4,8 +4,8 @@ run-name: Autogen - ${{ github.ref_name }}
 on:
   pull_request:
     paths:
-      - 'Autogen/**'
-      - '.github/workflows/Autogen.yml'
+      - "Autogen/**"
+      - ".github/workflows/Autogen.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,17 +16,17 @@ jobs:
     name: CANfigurator
     runs-on: ubuntu-latest
     permissions:
-        contents: write
+      contents: write
     steps:
       - name: Checkout Pull Request
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.AUTOFORMAT_COMMIT_TOKEN }}
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6  # v1.41.1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1.41.1
         with:
           install-modules: |
             Readonly
@@ -55,12 +55,12 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Save Changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: github.ref_type != 'tag'
         env:
           HOME: ${{ github.workspace }}
         with:
           default_author: github_actions
-          message: 'Automatic CANfigurator: Updated CAN files automatically'
-          fetch: 'false'
-          add: '--force Autogen/CAN/Inc/*.h Autogen/CAN/Doc/*.dbc'
+          message: "Automatic CANfigurator: Updated CAN files automatically"
+          fetch: "false"
+          add: "--force Autogen/CAN/Inc/*.h Autogen/CAN/Doc/*.dbc"

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   codeql:
+    if: ${{ !github.event.pull_request.draft }}
     name: CodeQL
     runs-on: ubuntu-latest
     permissions:
@@ -145,11 +147,11 @@ jobs:
           log_level: 'DEBUG'
 
   all:
+    if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All Linting
     needs: [ configs, codeql, perllinter, web ]
     runs-on: ubuntu-slim
     permissions: { }
-    if: always()
     steps:
       - name: Fail Linting
         if: >

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -31,15 +31,15 @@ jobs:
           fetch-depth: 1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
-          build-mode: 'none'
+          build-mode: "none"
 
       - name: Analyze CodeQL
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
-          category: '${{ matrix.language }}'
+          category: "${{ matrix.language }}"
 
   configs:
     name: Configuration Files
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 1
 
       - name: Validate Configuration Files
-        uses: Boeing/validate-configs-action@a31830f9bec7d3ec001cfab7951a966d08180a72  # v2.0.0
+        uses: Boeing/validate-configs-action@a31830f9bec7d3ec001cfab7951a966d08180a72 # v2.0.0
 
   perllinter:
     name: Perl Linter
@@ -68,9 +68,9 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6  # v1.41.1
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1.41.1
         with:
-          install-modules: 'Perl::Critic'
+          install-modules: "Perl::Critic"
 
       - name: Perl Critic Output
         run: |
@@ -121,11 +121,11 @@ jobs:
 
       - name: Upload Annotations
         if: failure() && github.event_name == 'pull_request'
-        uses: yuzutech/annotations-action@00b2d488bcba3bd01014dc073d276ef4a45d5c6c  # v0.6.0
+        uses: yuzutech/annotations-action@00b2d488bcba3bd01014dc073d276ef4a45d5c6c # v0.6.0
         with:
-          title: 'Perl Linter Findings'
+          title: "Perl Linter Findings"
           repo-token: ${{ github.token }}
-          input: 'perlcritic_annotations.json'
+          input: "perlcritic_annotations.json"
 
   web:
     name: Web Linter
@@ -140,18 +140,18 @@ jobs:
           fetch-depth: 1
 
       - name: HTML5 Validator
-        uses: Cyb3r-Jak3/html5validator-action@4ea5e57383ed7e14432ebbaae1b64893b7c5210b  # v8.0.0
+        uses: Cyb3r-Jak3/html5validator-action@4ea5e57383ed7e14432ebbaae1b64893b7c5210b # v8.0.0
         with:
-          root: 'Web'
-          css: 'true'
-          log_level: 'DEBUG'
+          root: "Web"
+          css: "true"
+          log_level: "DEBUG"
 
   all:
     if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All Linting
-    needs: [ configs, codeql, perllinter, web ]
+    needs: [configs, codeql, perllinter, web]
     runs-on: ubuntu-slim
-    permissions: { }
+    permissions: {}
     steps:
       - name: Fail Linting
         if: >

--- a/.github/workflows/PublishWeb.yml
+++ b/.github/workflows/PublishWeb.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches: ["main"]
     paths:
-      - 'Web/**'
-      - '.github/workflows/PublishWeb.yml'
+      - "Web/**"
+      - ".github/workflows/PublishWeb.yml"
   workflow_dispatch:
 
 concurrency:
@@ -31,12 +31,12 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: 'Web'
+          path: "Web"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -31,8 +31,7 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem == 'ubuntu-latest' && format('/tmp/sccache-{0}.sock', matrix.prefix) || '' }}
-      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || (matrix.prefix == 'Release' && '4227' || (matrix.prefix == 'MinSizeRel' && '4228' || '4229'))) || (matrix.operatingSystem == 'macos-latest' && (matrix.prefix == 'Debug' && '4326' || (matrix.prefix == 'Release' && '4327' || (matrix.prefix == 'MinSizeRel' && '4328' || '4329'))) || '') }}
+      SCCACHE_SERVER_PORT: ${{ matrix.prefix == 'Debug' && '4226' || (matrix.prefix == 'Release' && '4227' || (matrix.prefix == 'MinSizeRel' && '4228' || '4229')) }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -191,8 +190,6 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem == 'ubuntu-latest' && format('/tmp/sccache-{0}.sock', github.job) || '' }}
-      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || (matrix.operatingSystem == 'macos-latest' && '4326' || '') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -30,7 +30,7 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}-{1}.sock', matrix.prefix, matrix.operatingSystem) || '' }}
+      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache.sock' || '' }}
       SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || matrix.prefix == 'Release' && '4227' || matrix.prefix == 'MinSizeRel' && '4228' || '4229') || '' }}
     steps:
       - name: Checkout Repository
@@ -187,7 +187,7 @@ jobs:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache-ctest.sock' || '' }}
+        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache.sock' || '' }}
         SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || '' }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
+      - name: Start Shared Compilation Cache Server (Windows)
+        if: matrix.operatingSystem == 'windows-latest'
+        shell: pwsh
+        run: sccache --start-server
+
       - name: CMake Configuration (Unix)
         if: matrix.operatingSystem != 'windows-latest'
         shell: bash
@@ -207,6 +212,11 @@ jobs:
 
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Start Shared Compilation Cache Server (Windows)
+        if: matrix.operatingSystem == 'windows-latest'
+        shell: pwsh
+        run: sccache --start-server
 
       - name: CMake Configuration (Unix)
         if: matrix.operatingSystem != 'windows-latest'

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           release: ${{ env.ARM_GCC_VERSION }}
 
-      - name: Setup Shared Compilation Cache
+      - name: Setup Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -30,7 +30,8 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_NO_DAEMON: 1
+      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}-{1}.sock', matrix.prefix, matrix.operatingSystem) || '' }}
+      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || matrix.prefix == 'Release' && '4227' || matrix.prefix == 'MinSizeRel' && '4228' || '4229') || '' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -186,7 +187,8 @@ jobs:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-        SCCACHE_NO_DAEMON: 1
+        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache-ctest.sock' || '' }}
+        SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || '' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -355,12 +357,11 @@ jobs:
     permissions: { }
     steps:
       - name: Fail HOOTL Unit Tests
-        if: >
+        if: > # TODO Add prove once implemented
           ${{
             needs.cmake.result != 'success' ||
             needs.ctest.result != 'success' ||
-            needs.valgrind.result != 'success' ||
-            needs.prove.result != 'success'
+            needs.valgrind.result != 'success'
           }}
         run: |
           echo "One or more HOOTL unit test jobs have failed."

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -57,9 +57,7 @@ jobs:
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
-      - name: Start Shared Compilation Cache Server (Windows)
-        if: matrix.operatingSystem == 'windows-latest'
-        shell: pwsh
+      - name: Start Shared Compilation Cache Server
         run: sccache --start-server
 
       - name: CMake Configuration (Unix)
@@ -204,18 +202,16 @@ jobs:
       - name: Setup Shared Compilation Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-            path: ${{ env.SCCACHE_DIR }}
-            key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
-            restore-keys: |
-              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
-              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
+          restore-keys: |
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
 
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
-      - name: Start Shared Compilation Cache Server (Windows)
-        if: matrix.operatingSystem == 'windows-latest'
-        shell: pwsh
+      - name: Start Shared Compilation Cache Server
         run: sccache --start-server
 
       - name: CMake Configuration (Unix)

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true
       matrix:
         prefix: [ "Debug", "Release", "MinSizeRel", "RelWithDebInfo" ]
-        operatingSystem: [ ubuntu-latest, windows-latest, macos-latest ]
+        operatingSystem: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     env:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -3,13 +3,13 @@ run-name: Unit Tests - ${{ github.ref_name }}
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 env:
-  ARM_GCC_VERSION: '12.2.Rel1'
+  ARM_GCC_VERSION: "12.2.Rel1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -25,14 +25,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        prefix: [ "Debug", "Release", "MinSizeRel", "RelWithDebInfo" ]
+        prefix: ["Debug", "Release", "MinSizeRel", "RelWithDebInfo"]
         operatingSystem: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     env:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}.sock', matrix.prefix) || '' }}
-      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || (matrix.prefix == 'Release' && '4227' || (matrix.prefix == 'MinSizeRel' && '4228' || '4229'))) || '' }}
+      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem == 'ubuntu-latest' && format('/tmp/sccache-{0}.sock', matrix.prefix) || '' }}
+      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || (matrix.prefix == 'Release' && '4227' || (matrix.prefix == 'MinSizeRel' && '4228' || '4229'))) || (matrix.operatingSystem == 'macos-latest' && (matrix.prefix == 'Debug' && '4326' || (matrix.prefix == 'Release' && '4327' || (matrix.prefix == 'MinSizeRel' && '4328' || '4329'))) || '') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,12 +40,12 @@ jobs:
           fetch-depth: 1
 
       - name: Install Arm Toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@0725d97b026acf7fc8e22dfd5bee912998879ba8  # v1.12.3
+        uses: carlosperate/arm-none-eabi-gcc-action@0725d97b026acf7fc8e22dfd5bee912998879ba8 # v1.12.3
         with:
           release: ${{ env.ARM_GCC_VERSION }}
 
       - name: Setup Shared Compilation Cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-${{ github.ref_name }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload Ubuntu RelWithDebInfo Builds
         if: matrix.prefix == 'RelWithDebInfo' && matrix.operatingSystem == 'ubuntu-latest'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-release-with-debug-info
           path: build/${{ matrix.prefix }}/*.elf
@@ -181,23 +181,23 @@ jobs:
     needs: cmake
     runs-on: ${{ matrix.operatingSystem }}
     permissions:
-        contents: read
-        actions: write
+      contents: read
+      actions: write
     strategy:
-        fail-fast: true
-        matrix:
-          operatingSystem: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
+      fail-fast: true
+      matrix:
+        operatingSystem: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     env:
-        SCCACHE_DIR: ${{ github.workspace }}/sccache
-        SCCACHE_LOG: "info"
-        SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}.sock', github.job) || '' }}
-        SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || '' }}
+      SCCACHE_DIR: ${{ github.workspace }}/sccache
+      SCCACHE_LOG: "info"
+      SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
+      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem == 'ubuntu-latest' && format('/tmp/sccache-{0}.sock', github.job) || '' }}
+      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || (matrix.operatingSystem == 'macos-latest' && '4326' || '') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-            fetch-depth: 1
+          fetch-depth: 1
 
       - name: Setup Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -218,105 +218,105 @@ jobs:
         if: matrix.operatingSystem != 'windows-latest'
         shell: bash
         run: |
-            set -o pipefail
-            echo "<details><summary>CMake Configuration (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            cmake --preset HOOTLTest -DCMAKE_C_COMPILER_LAUNCHER=sccache 2>&1 | tee -a $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          set -o pipefail
+          echo "<details><summary>CMake Configuration (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          cmake --preset HOOTLTest -DCMAKE_C_COMPILER_LAUNCHER=sccache 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: CMake Configuration (Windows)
         if: matrix.operatingSystem == 'windows-latest'
         shell: pwsh
         run: |
-            echo "<details><summary>CMake Configuration (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            cmake --preset HOOTLTest -DCMAKE_C_COMPILER_LAUNCHER=sccache 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "<details><summary>CMake Configuration (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          cmake --preset HOOTLTest -DCMAKE_C_COMPILER_LAUNCHER=sccache 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: CMake Build (Unix)
         if: matrix.operatingSystem != 'windows-latest'
         shell: bash
         run: |
-            set -o pipefail
-            echo "<details><summary>CMake Build (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            cmake --build --preset HOOTLTest 2>&1 | tee -a $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          set -o pipefail
+          echo "<details><summary>CMake Build (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          cmake --build --preset HOOTLTest 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: CMake Build (Windows)
         if: matrix.operatingSystem == 'windows-latest'
         shell: pwsh
         run: |
-            echo "<details><summary>CMake Build (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            cmake --build --preset HOOTLTest 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "<details><summary>CMake Build (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          cmake --build --preset HOOTLTest 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Run CTest (Unix)
         if: matrix.operatingSystem != 'windows-latest'
         shell: bash
         run: |
-            set -o pipefail
-            echo "<details open><summary>Run CTest (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            ctest --output-on-failure --test-dir build/HOOTLTest 2>&1 | tee -a $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          set -o pipefail
+          echo "<details open><summary>Run CTest (HOOTLTest)</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          ctest --output-on-failure --test-dir build/HOOTLTest 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Run CTest (Windows)
         if: matrix.operatingSystem == 'windows-latest'
         shell: pwsh
         run: |
-            echo "<details open><summary>Run CTest (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            ctest --output-on-failure --test-dir build/HOOTLTest 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "<details open><summary>Run CTest (HOOTLTest)</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          ctest --output-on-failure --test-dir build/HOOTLTest 2>&1 | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Shared Compilation Cache Errors (Unix)
         if: matrix.operatingSystem != 'windows-latest'
         shell: bash
         run: |
-            set -o pipefail
-            if [ -f "$SCCACHE_ERROR_LOG" ]; then
-              echo "<details><summary>Shared Compilation Cache Errors</summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-              cat "$SCCACHE_ERROR_LOG" | tee -a $GITHUB_STEP_SUMMARY
-              echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-            fi
+          set -o pipefail
+          if [ -f "$SCCACHE_ERROR_LOG" ]; then
+            echo "<details><summary>Shared Compilation Cache Errors</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            cat "$SCCACHE_ERROR_LOG" | tee -a $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Shared Compilation Cache Errors (Windows)
         if: matrix.operatingSystem == 'windows-latest'
         shell: pwsh
         run: |
-            if (Test-Path $env:SCCACHE_ERROR_LOG) {
-              echo "<details><summary>Shared Compilation Cache Errors</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              Get-Content $env:SCCACHE_ERROR_LOG | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-              echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            }
+          if (Test-Path $env:SCCACHE_ERROR_LOG) {
+            echo "<details><summary>Shared Compilation Cache Errors</summary>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            Get-Content $env:SCCACHE_ERROR_LOG | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            echo "``````" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            echo "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            echo "</details>" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          }
 
   valgrind:
     name: Valgrind
@@ -331,7 +331,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Valgrind
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: valgrind
 
@@ -350,7 +350,7 @@ jobs:
     if: false # TODO Implement formal testing for CANfigurator
     name: Prove CANfigurator
     runs-on: ubuntu-slim
-    permissions: { }
+    permissions: {}
     steps:
       - name: Placeholder for CANfigurator Unit Tests
         run: echo "Placeholder for CANfigurator unit tests using Prove (or some other testing framework)."
@@ -358,9 +358,9 @@ jobs:
   all:
     if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All HOOTL Unit Tests
-    needs: [ cmake, ctest, valgrind ] # TODO Add prove once implemented
+    needs: [cmake, ctest, valgrind] # TODO Add prove once implemented
     runs-on: ubuntu-slim
-    permissions: { }
+    permissions: {}
     steps:
       - name: Fail HOOTL Unit Tests
         if: > # TODO Add prove once implemented

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -30,7 +30,7 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_IDLE_TIMEOUT: 0
+      SCCACHE_NO_DAEMON: 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -186,7 +186,7 @@ jobs:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-        SCCACHE_IDLE_TIMEOUT: 0
+        SCCACHE_NO_DAEMON: 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -180,7 +180,7 @@ jobs:
     strategy:
         fail-fast: true
         matrix:
-          operatingSystem: [ ubuntu-latest, windows-latest, macos-latest ]
+          operatingSystem: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && fromJson('["ubuntu-latest"]') || fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     env:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -47,11 +47,11 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-${{ github.job }}-${{ github.run_id }}
+          key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-${{ github.ref_name }}
           restore-keys: |
-            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-${{ github.job }}-
-            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-
-            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-${{ github.ref_name }}
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
 
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -199,11 +199,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
             path: ${{ env.SCCACHE_DIR }}
-            key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-${{ github.job }}-${{ github.run_id }}
+            key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
             restore-keys: |
-              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-${{ github.job }}-
-              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.ref_name }}-
-              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-
+              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
+              sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
 
       - name: Setup Shared Compilation Cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -199,7 +199,7 @@ jobs:
         with:
             fetch-depth: 1
 
-      - name: Setup Shared Compilation Cache
+      - name: Setup Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -31,8 +31,8 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache.sock' || '' }}
-      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || matrix.prefix == 'Release' && '4227' || matrix.prefix == 'MinSizeRel' && '4228' || '4229') || '' }}
+      SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}.sock', matrix.prefix) || '' }}
+      SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && (matrix.prefix == 'Debug' && '4226' || (matrix.prefix == 'Release' && '4227' || (matrix.prefix == 'MinSizeRel' && '4228' || '4229'))) || '' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -188,7 +188,7 @@ jobs:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
-        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && '/tmp/sccache.sock' || '' }}
+        SCCACHE_SERVER_UDS: ${{ matrix.operatingSystem != 'windows-latest' && format('/tmp/sccache-{0}.sock', github.job) || '' }}
         SCCACHE_SERVER_PORT: ${{ matrix.operatingSystem == 'windows-latest' && '4226' || '' }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -337,6 +337,7 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
   prove:
+    if: false # TODO Implement formal testing for CANfigurator
     name: Prove CANfigurator
     runs-on: ubuntu-slim
     permissions: { }
@@ -346,7 +347,7 @@ jobs:
 
   all:
     name: Completed All HOOTL Unit Tests
-    needs: [ cmake, ctest, valgrind, prove ]
+    needs: [ cmake, ctest, valgrind ] # TODO Add prove once implemented
     runs-on: ubuntu-slim
     permissions: { }
     if: always()

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -346,11 +346,11 @@ jobs:
         run: echo "Placeholder for CANfigurator unit tests using Prove (or some other testing framework)."
 
   all:
+    if: ${{ !github.event.pull_request.draft && always() }}
     name: Completed All HOOTL Unit Tests
     needs: [ cmake, ctest, valgrind ] # TODO Add prove once implemented
     runs-on: ubuntu-slim
     permissions: { }
-    if: always()
     steps:
       - name: Fail HOOTL Unit Tests
         if: >

--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -30,6 +30,7 @@ jobs:
       SCCACHE_DIR: ${{ github.workspace }}/sccache
       SCCACHE_LOG: "info"
       SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
+      SCCACHE_IDLE_TIMEOUT: 0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -185,6 +186,7 @@ jobs:
         SCCACHE_DIR: ${{ github.workspace }}/sccache
         SCCACHE_LOG: "info"
         SCCACHE_ERROR_LOG: ${{ github.workspace }}/sccache-error.log
+        SCCACHE_IDLE_TIMEOUT: 0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -133,7 +133,7 @@
 			"type": "shell",
 			"dependsOrder": "sequence",
 			"dependsOn": [
-				"CMake: configure"
+													"CMake: configure"
 			],
 			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4PERTESTING"
 		},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -126,7 +126,7 @@
 			"dependsOn": [
 				"CMake: configure"
 			],
-			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4HELLO"
+												"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4HELLO"
 		},
 		{
 			"label": "CMake: configure and build G4PERTESTING",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -133,7 +133,7 @@
 			"type": "shell",
 			"dependsOrder": "sequence",
 			"dependsOn": [
-													"CMake: configure"
+				"CMake: configure"
 			],
 			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4PERTESTING"
 		},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -126,7 +126,7 @@
 			"dependsOn": [
 				"CMake: configure"
 			],
-												"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4HELLO"
+			"command": "cmake --build --preset ${command:cmake.activeBuildPresetName} --target G4HELLO"
 		},
 		{
 			"label": "CMake: configure and build G4PERTESTING",


### PR DESCRIPTION
# Save CI/CD Trees and Microsoft Money

## Problem and Scope
Running CI/CD unnecessarily is bad

## Description
Run full CI/CD only when a PR is marked ready for review

## Gotchas and Limitations
Can hide problems until marked ready for review

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
- [ ] Runs select actions as soon as marked ready for review
- [x] Runs select actions on new pushes while ready for review
- [x] Skips select actions on new pushes while marked as a draft

## Larger Impact
Save trees and quicker CI/CD

## Additional Context and Ticket
Same strategy as in #470 
Resolves #473 