### PR TITLE
Read and reset the variable set by the button read interrupt exactly once to prevent footguns and race conditions

### DIFF
--- a/ECU/Application/Inc/StateData.h
+++ b/ECU/Application/Inc/StateData.h
@@ -87,7 +87,9 @@ typedef volatile struct ECU_StateData {
 	uint8_t glv_soc;
 	uint8_t acu_error_warning_bits;
 	uint8_t inverter_fault_map;
+	bool ts_active_button_press_interrupt;
 	bool ts_active_button_pressed;
+	bool rtd_button_press_interrupt;
 	bool rtd_button_pressed;
 	bool ir_plus;
 	bool ir_minus;

--- a/ECU/Application/Src/CANdler.c
+++ b/ECU/Application/Src/CANdler.c
@@ -110,17 +110,15 @@ void ECU_CAN_MessageHandler(ECU_StateData *state_data, GRCAN_BUS_ID bus_id, GRCA
 
 			// LET IT BE KNOWN: these things are LSB FIRST, TODO: I'll get it right later
 			if (state_data->ecu_state == GR_GLV_ON) {
-				state_data->ts_active_button_pressed = dash_data->button_flags & 1;
+				state_data->ts_active_button_press_interrupt = dash_data->button_flags & 1;
 			} else {
-				state_data->ts_active_button_pressed = (dash_data->button_flags >> 2) & 1;
+				state_data->ts_active_button_press_interrupt = (dash_data->button_flags >> 2) & 1;
 			}
 
 			if (state_data->ecu_state == GR_PRECHARGE_COMPLETE) {
-				state_data->rtd_button_pressed = (dash_data->button_flags >> 1) & 1;
+				state_data->rtd_button_press_interrupt = (dash_data->button_flags >> 1) & 1;
 			} else if (state_data->ecu_state == GR_DRIVE_ACTIVE) {
-				state_data->rtd_button_pressed = (dash_data->button_flags >> 3) & 1;
-			} else {
-				state_data->rtd_button_pressed = false;
+				state_data->rtd_button_press_interrupt = (dash_data->button_flags >> 3) & 1;
 			}
 
 			break;

--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -60,20 +60,19 @@ void ECU_State_Tick(void)
 
 	// bmsFailure(&stateLump) || imdFailure(&stateLump);
 
-	if(stateLump.ts_active_button_press_interrupt) {
+	if (stateLump.ts_active_button_press_interrupt) {
 		stateLump.ts_active_button_press_interrupt = false;
 		stateLump.ts_active_button_pressed = true;
 	} else {
 		stateLump.ts_active_button_pressed = false;
 	}
 
-	if(stateLump.rtd_button_press_interrupt) {
+	if (stateLump.rtd_button_press_interrupt) {
 		stateLump.rtd_button_press_interrupt = false;
 		stateLump.rtd_button_pressed = true;
 	} else {
 		stateLump.rtd_button_pressed = false;
 	}
-
 
 	switch (stateLump.ecu_state) {
 		case GR_GLV_OFF:

--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -60,6 +60,21 @@ void ECU_State_Tick(void)
 
 	// bmsFailure(&stateLump) || imdFailure(&stateLump);
 
+	if(stateLump.ts_active_button_press_interrupt) {
+		stateLump.ts_active_button_press_interrupt = false;
+		stateLump.ts_active_button_pressed = true;
+	} else {
+		stateLump.ts_active_button_pressed = false;
+	}
+
+	if(stateLump.rtd_button_press_interrupt) {
+		stateLump.rtd_button_press_interrupt = false;
+		stateLump.rtd_button_pressed = true;
+	} else {
+		stateLump.rtd_button_pressed = false;
+	}
+
+
 	switch (stateLump.ecu_state) {
 		case GR_GLV_OFF:
 			ECU_GLV_Off(&stateLump);
@@ -106,7 +121,6 @@ void ECU_GLV_On(ECU_StateData *stateData)
 	if (stateData->ts_active_button_pressed /* && stateData->ir_plus*/) { // TODO: Talk to Owen if this is correct for precharge start confirmation
 		LOGOMATIC("GLV ON to PRECHARGE START!\n");
 		ECU_Transition_To_Precharge_Engaged(stateData);
-		stateData->ts_active_button_pressed = false;
 		return;
 	}
 }
@@ -142,7 +156,6 @@ void ECU_Precharge_Engaged(ECU_StateData *stateData)
 		LOGOMATIC("ERROR: ts_active PRESSED! PRECHARGE ENGAGED to TS DISCHARGE START!\n");
 		ECU_CAN_Send(GRCAN_BUS_PRIMARY, GRCAN_Debugger, GRCAN_DEBUG_2_0, "TS-P-ITR", 8);
 		ECU_Transition_To_Tractive_System_Discharge(stateData);
-		stateData->ts_active_button_pressed = false;
 		return;
 	}
 }
@@ -153,7 +166,6 @@ void ECU_Precharge_Complete(ECU_StateData *stateData)
 	if (stateData->ts_active_button_pressed) {
 		LOGOMATIC("TS Active Toggled Off. Discharging Tractive System.\n");
 		ECU_Transition_To_Tractive_System_Discharge(stateData);
-		stateData->ts_active_button_pressed = false;
 		return;
 	}
 	if (CriticalError(stateData)) {
@@ -177,11 +189,7 @@ void ECU_Precharge_Complete(ECU_StateData *stateData)
 		ECU_CAN_Send(GRCAN_BUS_DATA, GRCAN_TCM, GRCAN_ECU_ANALOG_DATA, &pedals_message, sizeof(pedals_message));
 		LOGOMATIC("PRECHARGE COMPLETE to DRIVE START/ACTIVE!\n");
 		ECU_Transition_To_Drive_Active(stateData);
-		stateData->rtd_button_pressed = false;
 		return;
-	} else {
-		// Demand that we only transition to drive active if the RTD button is pressed while pressing the brake.
-		stateData->rtd_button_pressed = false;
 	}
 }
 
@@ -205,7 +213,6 @@ void ECU_Drive_Active(ECU_StateData *stateData)
 		LOGOMATIC("Error: TS active button pressed in Drive Active state. Discharging Tractive System.\n");
 		ECU_Transition_To_Tractive_System_Discharge(stateData);
 		ECU_CAN_Send(GRCAN_BUS_PRIMARY, GRCAN_Debugger, GRCAN_DEBUG_2_0, "DA-CritE", 8);
-		stateData->ts_active_button_pressed = false;
 		return;
 	}
 
@@ -221,7 +228,6 @@ void ECU_Drive_Active(ECU_StateData *stateData)
 		if (vehicle_is_moving(stateData)) {
 			LOGOMATIC("Warning: Vehicle is moving during state transition.\n");
 		}
-		stateData->rtd_button_pressed = false;
 		return;
 	}
 

--- a/ECU/Test/Inc/can.h
+++ b/ECU/Test/Inc/can.h
@@ -378,11 +378,11 @@ int can_enqueue(CANHandle *canHandle, FDCANTxMessage *message);
 int can_release(CANHandle *handle); // deinit circular buffer and turn off can peripheral and gpios
 int can_add_filter(CANHandle *handle, FDCAN_FilterTypeDef *filter);
 uint8_t BytesToCANDLC(uint32_t num_bytes);
-    // alternatively use
-    // HAL_FDCAN_ConfigGlobalFilter() //important to accept nonmatching frames into
-    // HAL_FDCAN_ConfigFilter()
+// alternatively use
+// HAL_FDCAN_ConfigGlobalFilter() //important to accept nonmatching frames into
+// HAL_FDCAN_ConfigFilter()
 
-    // doesn't need a handle, CAN cores share peripheral clock
-    void can_set_clksource(uint32_t clksource); // ex. LL_RCC_FDCAN_CLKSOURCE_PCLK1 for STM32G474RE
+// doesn't need a handle, CAN cores share peripheral clock
+void can_set_clksource(uint32_t clksource); // ex. LL_RCC_FDCAN_CLKSOURCE_PCLK1 for STM32G474RE
 
 #endif

--- a/ECU/Test/Src/StateTicksTest.c
+++ b/ECU/Test/Src/StateTicksTest.c
@@ -36,6 +36,20 @@ static void ECU_Pseudo_State_Tick(ECU_StateData *stateLumpTest)
 		LOGOMATIC("TSSI: TS Normal\n");
 	}
 
+	if(stateLumpTest->ts_active_button_press_interrupt) {
+		stateLumpTest->ts_active_button_press_interrupt = false;
+		stateLumpTest->ts_active_button_pressed = true;
+	} else {
+		stateLumpTest->ts_active_button_pressed = false;
+	}
+
+	if(stateLumpTest->rtd_button_press_interrupt) {
+		stateLumpTest->rtd_button_press_interrupt = false;
+		stateLumpTest->rtd_button_pressed = true;
+	} else {
+		stateLumpTest->rtd_button_pressed = false;
+	}
+
 	switch (stateLumpTest->ecu_state) {
 		case GR_GLV_OFF:
 			ECU_GLV_Off(stateLumpTest);
@@ -80,7 +94,7 @@ int main(void)
 		// ## Step 0.1             ##
 		// ##########################
 		LOGOMATIC("Press and release RTD -> STAY IN GLV ON\n");
-		stateLumpTest.rtd_button_pressed = true;
+		stateLumpTest.rtd_button_press_interrupt = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_GLV_ON) {
 			LOGOMATIC("0.1 Failure: ecu state not in GLV ON\n");
@@ -137,7 +151,7 @@ int main(void)
 		// ## Step 0.3             ##
 		// ##########################
 		LOGOMATIC("Press TS ACTIVE: Go to PRECHARGE ENGAGE\n");
-		stateLumpTest.ts_active_button_pressed = true;
+		stateLumpTest.ts_active_button_press_interrupt = true;
 		stateLumpTest.ir_minus = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_PRECHARGE_ENGAGED) {
@@ -177,7 +191,7 @@ int main(void)
 		// ## Step 0.6             ##
 		// ##########################
 		LOGOMATIC("Press RTD -> STAY IN PRECHARGE COMPLETE\n");
-		stateLumpTest.rtd_button_pressed = true;
+		stateLumpTest.rtd_button_press_interrupt = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_PRECHARGE_COMPLETE) {
 			LOGOMATIC("0.6 Failure: ecu state not in precharge complete\n");
@@ -188,7 +202,7 @@ int main(void)
 			return 6;
 		}
 		LOGOMATIC("Release RTD -> STAY IN PRECHARGE COMPLETE\n");
-		stateLumpTest.rtd_button_pressed = false;
+		stateLumpTest.rtd_button_press_interrupt = false;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_PRECHARGE_COMPLETE) {
 			LOGOMATIC("0.6 Failure: ecu state not in precharge complete\n");
@@ -205,7 +219,7 @@ int main(void)
 		LOGOMATIC("Press and release the RTD button WHILE pressing the brake\n");
 		stateLumpTest.bse_signal = BSE_MAX;
 		LOGOMATIC("Press RTD\n");
-		stateLumpTest.rtd_button_pressed = true;
+		stateLumpTest.rtd_button_press_interrupt = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		LOGOMATIC("Release RTD\n");
 		ECU_Pseudo_State_Tick(&stateLumpTest);
@@ -335,7 +349,7 @@ int main(void)
 		// ## Step 0.15            ##
 		// ##########################
 		LOGOMATIC("Press RTD -> MOVE TO PRECHARGE COMPLETE\n");
-		stateLumpTest.rtd_button_pressed = !stateLumpTest.rtd_button_pressed;
+		stateLumpTest.rtd_button_press_interrupt = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_PRECHARGE_COMPLETE) {
 			LOGOMATIC("0.15 Failure: ecu state not in precharge complete\n");
@@ -392,7 +406,7 @@ int main(void)
 		// ## Step 0.18            ##
 		// ##########################
 		LOGOMATIC("Press TS Active Button -> MOVE to TS DISCHARGE\n");
-		stateLumpTest.ts_active_button_pressed = !stateLumpTest.ts_active_button_pressed;
+		stateLumpTest.ts_active_button_press_interrupt = true;
 		ECU_Pseudo_State_Tick(&stateLumpTest);
 		if (stateLumpTest.ecu_state != GR_TS_DISCHARGE) {
 			LOGOMATIC("0.18 Failure: ecu state not in ts discharge\n");

--- a/ECU/Test/Src/StateTicksTest.c
+++ b/ECU/Test/Src/StateTicksTest.c
@@ -36,14 +36,14 @@ static void ECU_Pseudo_State_Tick(ECU_StateData *stateLumpTest)
 		LOGOMATIC("TSSI: TS Normal\n");
 	}
 
-	if(stateLumpTest->ts_active_button_press_interrupt) {
+	if (stateLumpTest->ts_active_button_press_interrupt) {
 		stateLumpTest->ts_active_button_press_interrupt = false;
 		stateLumpTest->ts_active_button_pressed = true;
 	} else {
 		stateLumpTest->ts_active_button_pressed = false;
 	}
 
-	if(stateLumpTest->rtd_button_press_interrupt) {
+	if (stateLumpTest->rtd_button_press_interrupt) {
 		stateLumpTest->rtd_button_press_interrupt = false;
 		stateLumpTest->rtd_button_pressed = true;
 	} else {

--- a/Lib/Peripherals/TimedCAN/Src/can.c
+++ b/Lib/Peripherals/TimedCAN/Src/can.c
@@ -438,7 +438,7 @@ uint8_t BytesToCANDLC(uint32_t num_bytes)
 		return FDCAN_DLC_BYTES_48;
 	} else if (num_bytes <= 64) {
 		return FDCAN_DLC_BYTES_64;
-	} else {	// Should never happen
+	} else { // Should never happen
 		return FDCAN_DLC_BYTES_0;
 		LOGOMATIC("Invalid CAN data size after check: %ld\n", num_bytes);
 	}


### PR DESCRIPTION
…y once and reset in exactly one place that always executes

# <Feature Name>

## Problem and Scope


## Description


## Gotchas and Limitations


## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details


## Larger Impact


## Additional Context and Ticket
