### PR TITLE
Ignore `GNUmakefile` From Repo To Allow Personalized Make Targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ Icon\r
 
 # Perl
 local
+
+# Makefile
+GNUmakefile


### PR DESCRIPTION
# Ignore `GNUmakefile`

## Problem and Scope
Users want to add more make shortcuts but they are not cross-compatible with everyone else out of the box already

## Description
Add `GNUmakefile` to `.gitignore` so that they can have their own precedent `GNUmakefile` and just `include Makefile` at the top to merge both

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Create `GNUmakefile` with

```make
include Makefile

.PHONY: web

web:
        python3 -m http.server -d Web
```

- [x] Running just `make` follows default `all` target
- [x] Verified `make web` works
- [x] Verified `make all` works

## Larger Impact
Folks get more power and customization without sacrifice of cross-compatibility

## Additional Context and Ticket
Web serving as key motivator but can be extended easily