### PR TITLE
GitHub Action Initial Default Cache

### DIFF
--- a/.github/workflows/UnitTestsHOOTL.yml
+++ b/.github/workflows/UnitTestsHOOTL.yml
@@ -50,6 +50,7 @@ jobs:
           key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-${{ github.ref_name }}
           restore-keys: |
             sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-${{ github.ref_name }}
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-main
             sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ matrix.prefix }}-
             sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
 
@@ -203,6 +204,7 @@ jobs:
           key: sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
           restore-keys: |
             sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-${{ github.ref_name }}
+            sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-main
             sccache-${{ runner.os }}-${{ env.ARM_GCC_VERSION }}-${{ github.job }}-
 
       - name: Setup Shared Compilation Cache


### PR DESCRIPTION
# GitHub Initial Default Cache

## Problem and Scope
Cache restore fails on first action by fetching random matching reference name

## Description
Add restore key off of `main` first before just any reference name, on the belief that most PRs do not (initially) deviate from `main` at much at first

## Gotchas and Limitations
Heuristic

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Cache restore had 100% hits on first run for this PR

## Larger Impact
Cache should default to be as host as possible

## Additional Context and Ticket
Noticed on #479 