### PR TITLE
ECU ADC Different Alpha Values Per Signal

### DIFF
--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -486,7 +486,20 @@ int main(void)
 		static uint32_t adc_timer;
 		// ADC
 		if (adc_timer % 1000 == 0) {
-			ADC_UpdateAnalogValues_EMA(ADC_buffers, NUM_SIGNALS, 0.01, ADC_outputs);
+			static float alphas[] = {
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+				0.01,
+			};
+			ADC_UpdateAnalogValues_EMA_Multi(ADC_buffers, NUM_SIGNALS, alphas, ADC_outputs);
 			write_adc_values_to_state_data();
 		}
 		adc_timer++;

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -487,17 +487,7 @@ int main(void)
 		// ADC
 		if (adc_timer % 1000 == 0) {
 			static float alphas[] = {
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
-				0.01,
+			    0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01,
 			};
 			ADC_UpdateAnalogValues_EMA_Multi(ADC_buffers, NUM_SIGNALS, alphas, ADC_outputs);
 			write_adc_values_to_state_data();

--- a/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
+++ b/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
@@ -163,6 +163,11 @@ void DMA_Init(DMA_Init_Values *Init_Values);
 /// @param weighted_output Takes in the current output, overwrites with the new output
 void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, double alpha, uint16_t *weighted_output);
 
-void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, double alpha, uint16_t *weighted_output);
+/// @brief A smoothing function using an Exponential Moving Average with a different alpha per signal
+/// @param new_values An array of the most recent values
+/// @param num_signals Number of signals to be updated
+/// @param alphas The weights of the newest values (0.0 - 1.0)
+/// @param weighted_output Takes in the current output, overwrites with the new output
+void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output)
 
 #endif

--- a/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
+++ b/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
@@ -168,6 +168,6 @@ void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, 
 /// @param num_signals Number of signals to be updated
 /// @param alphas The weights of the newest values (0.0 - 1.0)
 /// @param weighted_output Takes in the current output, overwrites with the new output
-void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output)
+void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output);
 
 #endif

--- a/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
+++ b/Lib/FancyLayers-RENAME/ADC/Inc/gr_adc.h
@@ -161,13 +161,13 @@ void DMA_Init(DMA_Init_Values *Init_Values);
 /// @param num_signals Number of signals to be updated
 /// @param alpha The weight of the newest values (0.0 - 1.0)
 /// @param weighted_output Takes in the current output, overwrites with the new output
-void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, double alpha, uint16_t *weighted_output);
+void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, float alpha, uint16_t *weighted_output);
 
 /// @brief A smoothing function using an Exponential Moving Average with a different alpha per signal
 /// @param new_values An array of the most recent values
 /// @param num_signals Number of signals to be updated
 /// @param alphas The weights of the newest values (0.0 - 1.0)
 /// @param weighted_output Takes in the current output, overwrites with the new output
-void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output);
+void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, float alphas[], uint16_t *weighted_output);
 
 #endif

--- a/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
+++ b/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
@@ -217,6 +217,13 @@ void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, 
 	}
 }
 
+void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output)
+{
+	for (int i = 0; i < num_signals; ++i) {
+		weighted_output[i] = alphas[i] * new_values[i] + (1 - alphas[i]) * weighted_output[i];
+	}
+}
+
 // void updateAnalogInputs(void)
 // {
 //     float newValue;

--- a/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
+++ b/Lib/FancyLayers-RENAME/ADC/Src/gr_adc.c
@@ -210,14 +210,14 @@ void ADC_WeightedOutput(uint16_t *latest, float *weighted_output, int num_signal
 }
 */
 
-void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, double alpha, uint16_t *weighted_output)
+void ADC_UpdateAnalogValues_EMA(volatile uint16_t *new_values, int num_signals, float alpha, uint16_t *weighted_output)
 {
 	for (int i = 0; i < num_signals; ++i) {
 		weighted_output[i] = alpha * new_values[i] + (1 - alpha) * weighted_output[i];
 	}
 }
 
-void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, double alphas[], uint16_t *weighted_output)
+void ADC_UpdateAnalogValues_EMA_Multi(volatile uint16_t *new_values, int num_signals, float alphas[], uint16_t *weighted_output)
 {
 	for (int i = 0; i < num_signals; ++i) {
 		weighted_output[i] = alphas[i] * new_values[i] + (1 - alphas[i]) * weighted_output[i];


### PR DESCRIPTION
# Different Alpha Values Per Signal

## Problem and Scope
Different analog inputs may need different alpha values

## Description
Allow using an alpha value per input in addition to allowing just one alpha value

## Gotchas and Limitations
Also changed ADC to use floats internally

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
None, compiles

## Larger Impact
Makes analog inputs more configurable

## Additional Context and Ticket
Resolves #478