### PR TITLE
ECU CAN Must Specify FD Format

### DIFF
--- a/ECU/Application/Src/CANutils.c
+++ b/ECU/Application/Src/CANutils.c
@@ -36,6 +36,7 @@ void ECU_CAN_Send(GRCAN_BUS_ID bus, GRCAN_NODE_ID destNode, GRCAN_MSG_ID message
 	    .DataLength = BytesToCANDLC(size),
 	    .BitRateSwitch = FDCAN_BRS_OFF,
 	    .TxEventFifoControl = FDCAN_NO_TX_EVENTS,
+		.FDFormat = (bus == GRCAN_BUS_PRIMARY) ?  FDCAN_CLASSIC_CAN :  FDCAN_FD_CAN,
 	    .MessageMarker = 0,
 	};
 

--- a/ECU/Application/Src/CANutils.c
+++ b/ECU/Application/Src/CANutils.c
@@ -36,7 +36,7 @@ void ECU_CAN_Send(GRCAN_BUS_ID bus, GRCAN_NODE_ID destNode, GRCAN_MSG_ID message
 	    .DataLength = BytesToCANDLC(size),
 	    .BitRateSwitch = FDCAN_BRS_OFF,
 	    .TxEventFifoControl = FDCAN_NO_TX_EVENTS,
-		.FDFormat = (bus == GRCAN_BUS_PRIMARY) ?  FDCAN_CLASSIC_CAN :  FDCAN_FD_CAN,
+	    .FDFormat = (bus == GRCAN_BUS_PRIMARY) ? FDCAN_CLASSIC_CAN : FDCAN_FD_CAN,
 	    .MessageMarker = 0,
 	};
 

--- a/ECU/Test/Inc/can.h
+++ b/ECU/Test/Inc/can.h
@@ -385,4 +385,7 @@ uint8_t BytesToCANDLC(uint32_t num_bytes);
 // doesn't need a handle, CAN cores share peripheral clock
 void can_set_clksource(uint32_t clksource); // ex. LL_RCC_FDCAN_CLKSOURCE_PCLK1 for STM32G474RE
 
+#define FDCAN_CLASSIC_CAN 0
+#define FDCAN_FD_CAN 1
+
 #endif


### PR DESCRIPTION
# CAN Precision

## Problem and Scope
Data bus maxed out at 8 bytes

## Description
Explicitly specify `FDFormat` in CAN send function

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Tested with analog data (apps, steering, etc)

## Larger Impact
Critical to any data

## Additional Context and Ticket
Fixed in the parking lot under Penthouse