### PR TITLE
Fix Brake Pedal Percentage On ECU

### DIFF
--- a/ECU/Application/Src/StateUtils.c
+++ b/ECU/Application/Src/StateUtils.c
@@ -123,7 +123,18 @@ float CalcBrakePercent(volatile const ECU_StateData *stateData)
 	return 0;
 #endif
 
-	return (stateData->bse_signal - BSE_MIN) / (float)(BSE_MAX - BSE_MIN);
+	if (stateData->bse_signal <= BSE_MIN) {
+		return 0;
+	}
+
+	const uint16_t numerator = stateData->bse_signal - BSE_MIN;
+	const uint16_t denominator = BSE_MAX - BSE_MIN;
+
+	if (numerator > denominator) {
+		return 1.0f;
+	}
+
+	return (float)numerator / (float)denominator;
 }
 
 // TODO: reconsider deadzone

--- a/ECU/Application/Src/StateUtils.c
+++ b/ECU/Application/Src/StateUtils.c
@@ -123,7 +123,7 @@ float CalcBrakePercent(volatile const ECU_StateData *stateData)
 	return 0;
 #endif
 
-	return stateData->bse_signal / 4096.0f;
+	return (stateData->bse_signal - BSE_MIN) / (float)(BSE_MAX - BSE_MIN);
 }
 
 // TODO: reconsider deadzone


### PR DESCRIPTION
# Brake Percentage

## Problem and Scope
Brake percent function ignored min/max on BSE signal

## Description
Return actual brake percentage when using BSE off of min/max

## Gotchas and Limitations
Needs calibration

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Looks better

## Larger Impact
None

## Additional Context and Ticket
Found during testing