### PR TITLE
Map ADC Buffer Indecies To Names

### DIFF
--- a/ECU/Core/Inc/main.h
+++ b/ECU/Core/Inc/main.h
@@ -51,6 +51,32 @@ extern "C" {
 /* Exported types ------------------------------------------------------------*/
 /* USER CODE BEGIN ET */
 
+/* ADC mappings from `ADC_buffers` and `ADC_outputs` arrays to signal/sense names */
+enum {
+	/* Brake Signal Encoder - Signal */
+	ADC_BUFFER_SIG_BSE = 0,
+	/* Brake System Plausibility Device - Signal */
+	ADC_BUFFER_SIG_BSPD = 1,
+	/* Accelerator Pedal Position Sensor 1 - Signal */
+	ADC_BUFFER_SIG_APPS1 = 2,
+	/* Accelerator Pedal Position Sensor 2 - Signal */
+	ADC_BUFFER_SIG_APPS2 = 3,
+	/* Front Brake Pressure - Signal */
+	ADC_BUFFER_SIG_BRAKE_F = 4,
+	/* Rear Brake Pressure - Signal */
+	ADC_BUFFER_SIG_BRAKE_R = 5,
+	/* Auxiliary - Signal */
+	ADC_BUFFER_SIG_AUX = 6,
+	/* Brake System Plausibility Device - Sense */
+	ADC_BUFFER_SENSE_BSPD = 7,
+	/* Insulation Monitoring Device - Sense */
+	ADC_BUFFER_SENSE_IMD = 8,
+	/* Accumulator Management System - Sense */
+	ADC_BUFFER_SENSE_AMS = 9,
+	/* Steering Angle - Signal */
+	ADC_BUFFER_SIG_STEERING_ANGLE = 10,
+};
+
 /* USER CODE END ET */
 
 /* Exported constants --------------------------------------------------------*/

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -197,19 +197,19 @@ void read_digital(void)
 void write_adc_values_to_state_data(void)
 {
 	// analog
-	stateLump.bse_signal = ADC_outputs[0];
-	stateLump.bspd_signal = ADC_outputs[1];
-	stateLump.APPS1_Signal = ADC_outputs[2];
-	stateLump.APPS2_Signal = ADC_outputs[3];
-	stateLump.Brake_F_Signal = ADC_outputs[4];
-	stateLump.Brake_R_Signal = ADC_outputs[5];
-	stateLump.aux_signal = ADC_outputs[6];
-	stateLump.steering_angle_signal = ADC_outputs[10]; // TODO: convert to rad/deg...?
+	stateLump.bse_signal = ADC_outputs[ADC_BUFFER_SIG_BSE];
+	stateLump.bspd_signal = ADC_outputs[ADC_BUFFER_SIG_BSPD];
+	stateLump.APPS1_Signal = ADC_outputs[ADC_BUFFER_SIG_APPS1];
+	stateLump.APPS2_Signal = ADC_outputs[ADC_BUFFER_SIG_APPS2];
+	stateLump.Brake_F_Signal = ADC_outputs[ADC_BUFFER_SIG_BRAKE_F];
+	stateLump.Brake_R_Signal = ADC_outputs[ADC_BUFFER_SIG_BRAKE_R];
+	stateLump.aux_signal = ADC_outputs[ADC_BUFFER_SIG_AUX];
+	stateLump.steering_angle_signal = ADC_outputs[ADC_BUFFER_SIG_STEERING_ANGLE]; // TODO: convert to rad/deg...?
 
 	// TODO: determine conversion factors for all of these (uint to float)
-	stateLump.bspd_sense = ADC_outputs[7] / 4095.0 * 3.3;
-	stateLump.imd_sense = ADC_outputs[8] / 4095.0 * 3.3;
-	stateLump.ams_sense = ADC_outputs[9] / 4095.0 * 3.3;
+	stateLump.bspd_sense = ADC_outputs[ADC_BUFFER_SENSE_BSPD] / 4095.0 * 3.3;
+	stateLump.imd_sense = ADC_outputs[ADC_BUFFER_SENSE_IMD] / 4095.0 * 3.3;
+	stateLump.ams_sense = ADC_outputs[ADC_BUFFER_SENSE_AMS] / 4095.0 * 3.3;
 }
 
 void ADC_Configure(void)
@@ -536,7 +536,7 @@ int main(void)
 			}
 			lightControl(&stateLump);
 
-			Send_VCP_APPS(&stateLump, ADC_outputs[2], ADC_outputs[3]);
+			Send_VCP_APPS(&stateLump, ADC_outputs[ADC_BUFFER_SIG_APPS1], ADC_outputs[ADC_BUFFER_SIG_APPS2]);
 			// ADC_Logomatic();
 		}
 	}


### PR DESCRIPTION
# ADC Buffer Enum

## Problem and Scope
Seeing a wall of array indecies to other values makes debugging the raw values captured on ADC hard

## Description
Add an enum to map the indecies to their name so that the raw values can be accessed much more trivially

## Gotchas and Limitations
Update enum as you would update the numbers

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Double checked each index is the same

## Larger Impact
Debugging and printing raw values off of the ADC is easier

## Additional Context and Ticket
Thought of during testing