### PR TITLE
Power Level Initializes To 100A Setting

### DIFF
--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -31,8 +31,8 @@ ECU_StateData stateLump = {
     .ecu_state = GR_GLV_ON,
     // Assume ACU good at boot
     .acu_software_latch = 1,
-    // Startup at minimum power
-    .powerlevel = 0,
+    // Startup at maximum power
+    .powerlevel = 5,
     // See CANdo specification
     .torquemap = 1,
     // APPS Deadzone

--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -31,8 +31,8 @@ ECU_StateData stateLump = {
     .ecu_state = GR_GLV_ON,
     // Assume ACU good at boot
     .acu_software_latch = 1,
-    // Startup at maximum power
-    .powerlevel = 5,
+    // Startup at just above minimum power
+    .powerlevel = 1,
     // See CANdo specification
     .torquemap = 1,
     // APPS Deadzone


### PR DESCRIPTION
# Default Power

## Problem and Scope
ECU currently sets the power level to 50 A on start, but we want to go fast by default

## Description
Start the power level at 100 A, continuing cyclically

## Gotchas and Limitations
None

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Requires physical driving-based testing

## Larger Impact
No goofs at acceleration event

## Additional Context and Ticket
Suggested by @kzwicker and potentially another person while testing #501 