### PR TITLE
Set ECU to Use HSE Clock

### DIFF
--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -552,9 +552,9 @@ void SystemClock_Config(void)
 	LL_FLASH_SetLatency(LL_FLASH_LATENCY_4);
 	while (LL_FLASH_GetLatency() != LL_FLASH_LATENCY_4) {}
 	LL_PWR_EnableRange1BoostMode();
-	LL_RCC_HSI_Enable();
-	/* Wait till HSI is ready */
-	while (LL_RCC_HSI_IsReady() != 1) {}
+	LL_RCC_HSE_Enable();
+	/* Wait till HSE is ready */
+	while (LL_RCC_HSE_IsReady() != 1) {}
 
 	LL_RCC_HSE_EnableCSS();
 	LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -556,8 +556,8 @@ void SystemClock_Config(void)
 	/* Wait till HSI is ready */
 	while (LL_RCC_HSI_IsReady() != 1) {}
 
-	LL_RCC_HSI_SetCalibTrimming(64);
-	LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSI, LL_RCC_PLLM_DIV_4, 80, LL_RCC_PLLR_DIV_2);
+	LL_RCC_HSE_EnableCSS();
+	LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, LL_RCC_PLLM_DIV_1, 20, LL_RCC_PLLR_DIV_2);
 	LL_RCC_PLL_EnableDomain_SYS();
 	LL_RCC_PLL_Enable();
 	/* Wait till PLL is ready */

--- a/ECU/FIXME.md
+++ b/ECU/FIXME.md
@@ -1,9 +1,0 @@
-# Configuration Changes
-
-## Clock Accuracy
-
-A Nucleo-G474RE does not have an external crystal, but Big Bird does
-
-Once Big Bird is received switch from HSI (High-Speed Internal) to HSE (High-Speed External)
-
-See 3a18f2a7ae1b65bfdcec40b5623e33ac09b32374 where it was found that the Nucleo requires HSI and the swithc HSE -> HSI took place


### PR DESCRIPTION
# Set ECU Off Of HSE Clock

## Problem and Scope
ECU uses HSI which is less accurate

## Description
ECU to use HSE instead of HSI, at the same speed

## Gotchas and Limitations
Must test

## Testing
- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Requires independent testing prior to merge

## Larger Impact
Slight stability increase

## Additional Context and Ticket
None