### PR TITLE
Resolve CCU Clock To 160 MHz

### DIFF
--- a/CCU/Application/Src/CANdler.c
+++ b/CCU/Application/Src/CANdler.c
@@ -79,11 +79,11 @@ void CAN_Configure(void)
 	canCfg.hal_fdcan_init.ProtocolException = ENABLE;
 	canCfg.hal_fdcan_init.NominalPrescaler = 1;
 	canCfg.hal_fdcan_init.NominalSyncJumpWidth = 16;
-	canCfg.hal_fdcan_init.NominalTimeSeg1 = 127; // Updated for 170MHz: (1+127+42)*1 = 170 ticks -> 1 Mbps
-	canCfg.hal_fdcan_init.NominalTimeSeg2 = 42;
+	canCfg.hal_fdcan_init.NominalTimeSeg1 = 119; // Setup for (1+119+40)*1 = 160 ticks which at 160 MHz yields 1 Mbps
+	canCfg.hal_fdcan_init.NominalTimeSeg2 = 40;
 	canCfg.hal_fdcan_init.DataPrescaler = 8;
 	canCfg.hal_fdcan_init.DataSyncJumpWidth = 16;
-	canCfg.hal_fdcan_init.DataTimeSeg1 = 15; // Updated for 170MHz: (1+15+5)*8 = 168 ticks -> ~5 Mbps
+	canCfg.hal_fdcan_init.DataTimeSeg1 = 15; // Ignored as we are using CAN 2.0B without BRS
 	canCfg.hal_fdcan_init.DataTimeSeg2 = 5;
 	canCfg.hal_fdcan_init.StdFiltersNbr = 0;
 	canCfg.hal_fdcan_init.ExtFiltersNbr = 2;

--- a/CCU/Core/Src/main.c
+++ b/CCU/Core/Src/main.c
@@ -178,14 +178,14 @@ void SystemClock_Config(void)
 	while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {}
 
 	/* Insure 1us transition state at intermediate medium speed clock*/
-	for (__IO uint32_t i = (170 >> 1); i != 0; i--)
+	for (__IO uint32_t i = (160 >> 1); i != 0; i--)
 		;
 
 	/* Set AHB prescaler*/
 	LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
 	LL_RCC_SetAPB1Prescaler(LL_RCC_APB1_DIV_1);
 	LL_RCC_SetAPB2Prescaler(LL_RCC_APB2_DIV_1);
-	LL_SetSystemCoreClock(170000000);
+	LL_SetSystemCoreClock(160000000);
 
 	/* Update the time base */
 	if (HAL_InitTick(TICK_INT_PRIORITY) != HAL_OK) {


### PR DESCRIPTION
# Fix CCU Clock

## Problem and Scope
CCU views milliseconds as happening slower (or maybe faster, perspective is weird) then it should be

## Description
Adjust back to 160 MHz = 160 MHz and align CAN time segments

## Gotchas and Limitations
Needs testing but nothing else CCU has been tested anyway

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
Needs testing or at least validation and not having tested anything yet

## Larger Impact
CCU correctness

## Additional Context and Ticket
Caught by @kzwicker