### PR TITLE
APPS/BSE Require Over 25% Pedal Travel, Not Violated If Under 5% Pedal Travel

### DIFF
--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -246,7 +246,7 @@ void ECU_Drive_Active(ECU_StateData *stateData)
 
 	if (APPS_BSE_Violation(stateData)) {
 		stateData->apps_bse_violation = true;
-	} else if (CalcAccPedalTravel(stateData) < stateData->apps_deadzone) {
+	} else if (CalcAccPedalTravel(stateData) < (stateData->apps_deadzone + 0.05f)) {
 		stateData->apps_bse_violation = false;
 	}
 

--- a/ECU/Application/Src/StateUtils.c
+++ b/ECU/Application/Src/StateUtils.c
@@ -127,7 +127,7 @@ bool APPS_BSE_Violation(volatile const ECU_StateData *stateData)
 	return false;
 #endif
 
-	return PressingBrake(stateData) && CalcAccPedalTravel(stateData) > stateData->apps_deadzone;
+	return PressingBrake(stateData) && CalcAccPedalTravel(stateData) > (0.25f + stateData->apps_deadzone);
 }
 
 bool PressingBrake(volatile const ECU_StateData *stateData)


### PR DESCRIPTION
# Hot Fix APPS/BSE

## Problem and Scope
Set violation at any acceptable APPS percentage, unset at no throttle

## Description
Ensure we incorporate both limits

## Gotchas and Limitations
No grace period per rules

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Pending drive testing

## Larger Impact
None

## Additional Context and Ticket
Found during testing

<img width="659" height="217" alt="image" src="https://github.com/user-attachments/assets/fe1989f9-6048-41ef-a968-baced8765be4" />