### PR TITLE
DO NOT MERGE - Verify APPS/BSE Violation Occurences - DO NOT MERGE

### DIFF
--- a/ECU/Application/Inc/Lights.h
+++ b/ECU/Application/Inc/Lights.h
@@ -12,6 +12,8 @@
  *
  * @return void
  */
+void BrakeLightControl(ECU_StateData *stateLump);
+void dashLights(ECU_StateData *stateLump);
 void lightControl(ECU_StateData *stateData);
 
 #endif

--- a/ECU/Application/Src/Lights.c
+++ b/ECU/Application/Src/Lights.c
@@ -13,7 +13,13 @@
 
 void BrakeLightControl(ECU_StateData *stateLump)
 {
+	static uint32_t brake_light_start_millis;
+
 	if (PressingBrake(stateLump)) {
+		brake_light_start_millis = MillisecondsSinceBoot();
+	}
+
+	if (MillisecondsSinceBoot() - brake_light_start_millis < 100) {
 		LL_GPIO_SetOutputPin(BRAKE_LIGHT_GPIO_Port, BRAKE_LIGHT_Pin);
 	} else {
 		LL_GPIO_ResetOutputPin(BRAKE_LIGHT_GPIO_Port, BRAKE_LIGHT_Pin);

--- a/ECU/Application/Src/StateTicks.c
+++ b/ECU/Application/Src/StateTicks.c
@@ -245,6 +245,9 @@ void ECU_Drive_Active(ECU_StateData *stateData)
 	}
 
 	if (APPS_BSE_Violation(stateData)) {
+		// FIXME Strongly illegal! We are not allowed to do this at all! EV.9.7.3
+		buzzer_start_millis = millis_since_boot + MAX_BUZZER_TIME_MS - 100;
+		// FIXME Strongly illegal! We are not allowed to do this at all! EV.9.7.3
 		stateData->apps_bse_violation = true;
 	} else if (CalcAccPedalTravel(stateData) < (stateData->apps_deadzone + 0.05f)) {
 		stateData->apps_bse_violation = false;

--- a/ECU/Core/Src/main.c
+++ b/ECU/Core/Src/main.c
@@ -485,6 +485,8 @@ int main(void)
 	LOGOMATIC("Boot completed at %lu ms\n", MillisecondsSinceBoot());
 
 	while (MillisecondsSinceBoot() < 5000) { // Notes per Andrey and Ryan
+		BrakeLightControl(&stateLump);
+		dashLights(&stateLump);
 		LL_mDelay(1);
 		ADC_UpdateAnalogValues_EMA(ADC_buffers, NUM_SIGNALS, adc_alpha, ADC_outputs);
 		write_adc_values_to_state_data();


### PR DESCRIPTION
# Bug Test APPS/BSE 

## Problem and Scope
Suspect transient APPS/BSE violations are causing issues

## Description
If the apps/bse violation occurs then sound the buzzer until it finishes plus 100 ms

## Gotchas and Limitations
> [!CAUTION]
> This PR stands in direct violation to
> > EV.9.7.3 The vehicle must not make other sounds similar to the Ready to Drive Sound.
> As a result it should NOT be merged without changing

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [x] Human tested

### Testing Details
Driver will tell us if they hear a sound

## Larger Impact
Try and identify momentary APPS/BSE violation

## Additional Context and Ticket
See [Discord](https://discord.com/channels/756738476887638107/1254635893306953769/1513326062367674481)