### PR TITLE
Add Physical Bus Wiring To `GRCAN.CANdo` As Per-Bus `nodes` Lists

### DIFF
--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -12,10 +12,6 @@ Bus ID:
     id: 3
     max_dlc: 8
 
-# physical topology: which devices are physically wired to each CAN bus.
-# Hand-editable by design. Device names must match the GR ID section and bus
-# names must match the Bus ID section above. Buses omitted here (e.g. Testing)
-# are treated as unrestricted. Mirrors can_topology.json from the GRCAN-Web viewer.
 physical topology:
   Primary:
     - ECU

--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -52,6 +52,7 @@ Bus ID:
       - Charger
       - IMD
       - EM
+      - Charging SDC
 
 routing:
   messages:

--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -12,6 +12,53 @@ Bus ID:
     id: 3
     max_dlc: 8
 
+# physical topology: which devices are physically wired to each CAN bus.
+# Hand-editable by design. Device names must match the GR ID section and bus
+# names must match the Bus ID section above. Buses omitted here (e.g. Testing)
+# are treated as unrestricted. Mirrors can_topology.json from the GRCAN-Web viewer.
+physical topology:
+  Primary:
+    - ECU
+    - TCM
+    - ACU
+    - DGPS
+    - GR Inv
+    - DTI Inv
+    - Fan Ctrl 1
+    - Fan Ctrl 2
+    - Fan Ctrl 3
+    - EM
+    - Dash Panel
+    - HV DC-DC
+    - LV DC-DC
+  Data:
+    - ECU
+    - TCM
+    - ACU
+    - DGPS
+    - TireTemp FL
+    - TireTemp FR
+    - TireTemp RL
+    - TireTemp RR
+    - BrakeTemp FL
+    - BrakeTemp FR
+    - BrakeTemp RL
+    - BrakeTemp RR
+    - Suspension FL
+    - Suspension FR
+    - Suspension RL
+    - Suspension RR
+    - InboardFloor FL
+    - InboardFloor FR
+    - InboardFloor RL
+    - InboardFloor RR
+  Charger:
+    - CCU
+    - ACU
+    - Charger
+    - IMD
+    - EM
+
 routing:
   messages:
     ACU:

--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -5,55 +5,53 @@ Bus ID:
   Primary:
     id: 1
     max_dlc: 8
+    nodes:
+      - ECU
+      - TCM
+      - ACU
+      - DGPS
+      - GR Inv
+      - DTI Inv
+      - Fan Ctrl 1
+      - Fan Ctrl 2
+      - Fan Ctrl 3
+      - EM
+      - Dash Panel
+      - HV DC-DC
+      - LV DC-DC
   Data:
     id: 2
     max_dlc: 64
+    nodes:
+      - ECU
+      - TCM
+      - ACU
+      - DGPS
+      - TireTemp FL
+      - TireTemp FR
+      - TireTemp RL
+      - TireTemp RR
+      - BrakeTemp FL
+      - BrakeTemp FR
+      - BrakeTemp RL
+      - BrakeTemp RR
+      - Suspension FL
+      - Suspension FR
+      - Suspension RL
+      - Suspension RR
+      - InboardFloor FL
+      - InboardFloor FR
+      - InboardFloor RL
+      - InboardFloor RR
   Charger:
     id: 3
     max_dlc: 8
-
-physical topology:
-  Primary:
-    - ECU
-    - TCM
-    - ACU
-    - DGPS
-    - GR Inv
-    - DTI Inv
-    - Fan Ctrl 1
-    - Fan Ctrl 2
-    - Fan Ctrl 3
-    - EM
-    - Dash Panel
-    - HV DC-DC
-    - LV DC-DC
-  Data:
-    - ECU
-    - TCM
-    - ACU
-    - DGPS
-    - TireTemp FL
-    - TireTemp FR
-    - TireTemp RL
-    - TireTemp RR
-    - BrakeTemp FL
-    - BrakeTemp FR
-    - BrakeTemp RL
-    - BrakeTemp RR
-    - Suspension FL
-    - Suspension FR
-    - Suspension RL
-    - Suspension RR
-    - InboardFloor FL
-    - InboardFloor FR
-    - InboardFloor RL
-    - InboardFloor RR
-  Charger:
-    - CCU
-    - ACU
-    - Charger
-    - IMD
-    - EM
+    nodes:
+      - CCU
+      - ACU
+      - Charger
+      - IMD
+      - EM
 
 routing:
   messages:


### PR DESCRIPTION
# Physical Bus Wiring In `GRCAN.CANdo`

## Problem and Scope
`GRCAN.CANdo` is the source of truth for CAN configuration, but the physical bus wiring — which nodes are actually wired to which CAN bus — lived only in GRCAN-Web's separate `can_topology.json`, moved out of this repo in #521. That file is what validates routes added through the viewer, so the constraint the editor enforces was not in the file it constrains.

## Description
Adds a hand-editable `nodes` list to each bus in `Autogen/CAN/Doc/GRCAN.CANdo`'s `Bus ID` section, recording which nodes are physically wired to that bus (`Primary`, `Data`, `Charger`). Data imported from GRCAN-Web's `can_topology.json` (`Gaucho-Racing/GRCAN-Web`, HEAD `f790c93`).

Membership sits on the bus record it constrains rather than in a separate top-level section, so the bus name is not repeated as a second key set that nothing reconciles against `Bus ID`. That matters because a topology key that drifts from its `Bus ID` name would not loosen the check — `PhysicalTopology.isOnBus` returns `false` for a bus it does not recognize, and `formRoutingAdd.js` hard-blocks on that for both sender and receiver — so a renamed or mistyped bus would silently lock the entire bus out of the routing form.

Reconciled with `routing`: added `HV DC-DC` and `LV DC-DC` to `Primary` — both transmit `DC-DC Status` there per the authoritative routing — which the imported viewer file omits.

## Gotchas and Limitations
Record-only — no Perl parser consumes `nodes`, so no generated headers or DBCs change. Enforcement still lives only in the viewer, which means it only guards routes typed into its form; routes already present in `GRCAN.CANdo` are never checked.

Two routed-but-unlisted nodes remain. `Debugger` is the intentional always-allowed exemption. `Charging SDC` is not: `routing` has `Debugger → Charging SDC: Ping` on `Charger`, but `Charging SDC` is not wired to `Charger` in this list and is not exempt in the viewer. Either the route or the list is wrong — needs a call before this data is enforced anywhere.

`Testing` has no `nodes` list because nothing is wired to it. Note that the viewer treats a bus it has no entry for as allowing nothing, not as unrestricted.

Device and bus names must stay in sync with the `GR ID` section by hand.

## Testing

- [x] HOOTL testing
- [ ] HITL testing
- [ ] Human tested

### Testing Details
All six parsers (`Bus`, `CAN`, `DBC`, `GR`, `MSG`, `STRUCT`) were run against `main`, against this branch, and against a variant using inline flow lists. Every generated header in `Autogen/CAN/Inc` and all three `.dbc` files are byte-identical in every case — `BusParser.pl`'s child scan and `DBCparser.pl`'s `parse_bus_id` ignore keys they do not recognize, including list items at indent 6, and this holds even when a bus also carries a multi-line `comment`.

## Larger Impact
Physical wiring now sits alongside the logical bus definition and the routing table in the authoritative CANdo file, instead of only in the web viewer.

## Additional Context and Ticket
Physical-wiring data originally moved to GRCAN-Web in #521.

Two follow-ups. GRCAN-Web's `can_topology.json` should derive from this section rather than remain a second copy of the constraint — the two already disagree, since the JSON omits `HV DC-DC` and `LV DC-DC` on `Primary` while routing has both sending there. And enforcement should also run where the CANdo lives: `DBCparser.pl` already parses `Bus ID` and `routing` in one pass, so asserting that every routed sender and receiver is on its bus is cheap. The exemption set is currently hardcoded in `physicalTopology.js` (`Debugger`, `ALL`) and would need to be expressed in the CANdo for two enforcers to agree.
