### PR TITLE
Remove Thousands Separators From CANdo Numeric Values

### DIFF
--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -536,7 +536,7 @@ Message ID:
       data type: u32
       units: ms
       scaled min: 0
-      scaled max: 4,294,967,296
+      scaled max: 4294967296
       map equation: "1x"
   ECU Status 1:
     MSG ID: 0x003

--- a/Autogen/CAN/Src/DBCparser.pl
+++ b/Autogen/CAN/Src/DBCparser.pl
@@ -9,7 +9,7 @@
 # (which equals the corresponding "Bus ID:" name).
 #
 # Per-file DBC validity is enforced by:
-#   - numeric ranges stripped of thousands separators (no commas in numbers)
+#   - numeric ranges use plain integers (no thousands separators)
 #   - identifiers normalized to [A-Za-z_][A-Za-z0-9_]* (leading digits prefixed)
 #   - identifier length capped at 32 chars; long message names dedup leading
 #     tokens that already appear in the sender, and any composed name still
@@ -572,7 +572,6 @@ sub _to_number {
 	my ($v) = @_;
 	if ( !defined $v ) { return 0; }
 	$v =~ s/["'\s]//gsmx;
-	$v =~ s/,//gsmx;
 	if ( $v !~ /^-?\d/smx ) { return 0; }
 	return ( $v + 0 );
 }


### PR DESCRIPTION
## Summary

The `Ping` message's `Timestamp` field in `GRCAN.CANdo` had a `scaled max` value written as `4,294,967,296` with commas as thousands separators. YAML parsers read this as the string `'4,294,967,296'` instead of the integer `4294967296`, because commas are not part of YAML's numeric syntax.

## Changes

- **`Autogen/CAN/Doc/GRCAN.CANdo`**: Removed commas from the only thousands-separated number in the file (`scaled max: 4,294,967,296` to `scaled max: 4294967296`).
- **`Autogen/CAN/Src/DBCparser.pl`**: Removed the comma-stripping regex (`$v =~ s/,//gsmx;`) from the `_to_number` function, since no CANdo values contain commas anymore. Updated the header comment to reflect the new invariant (plain integers, no thousands separators).

## Verification

`grep -c ',[0-9]{3}' Autogen/CAN/Doc/GRCAN.CANdo` confirms this was the only occurrence. `perl -c DBCparser.pl` passes.