### PR TITLE
Normalize CANdo Dash Placeholders To YAML Null

### DIFF
--- a/Autogen/CAN/Doc/GRCAN.CANdo
+++ b/Autogen/CAN/Doc/GRCAN.CANdo
@@ -3568,9 +3568,9 @@ Message ID:
       comment: Write 1 inverts direction
       data type: b
       units: Enable
-      scaled min: "-"
-      scaled max: "-"
-      map equation: "-"
+      scaled min: ~
+      scaled max: ~
+      map equation: ~
   Inv Cmd:
     MSG ID: 0x017
     MSG LENGTH: 8
@@ -3611,9 +3611,9 @@ Message ID:
       comment: Write this to 1 every 100ms to enable Inv
       data type: b
       units: Enable
-      scaled min: "-"
-      scaled max: "-"
-      map equation: "-"
+      scaled min: ~
+      scaled max: ~
+      map equation: ~
   Fan Status:
     MSG ID: 0x018
     MSG LENGTH: 4


### PR DESCRIPTION
## Summary

Replace `"-"` (quoted dash) placeholders with YAML null (`~`) for boolean fields where `scaled min`, `scaled max`, and `map equation` are not applicable.

## Changes

In `Autogen/CAN/Doc/GRCAN.CANdo`, six fields used `"-"` as a placeholder meaning "not applicable":

- **Inv Config / Motor direction**: `scaled min`, `scaled max`, `map equation`
- **Inv Cmd / Drive enable**: `scaled min`, `scaled max`, `map equation`

Both are boolean fields (`data type: b`) where scaled range and map equation have no meaning. YAML null (`~`) is the idiomatic way to express "no value" rather than a quoted dash string.

## Parser Compatibility

The Perl parsers (`DBCparser.pl`) already handle `~` correctly:

- `parse_eq`: the string `"~"` does not match `$HYPHEN` or any equation pattern, so it falls through to the default `return (1, 0)` -- identical behavior to `"-"`.
- `_to_number`: `"~"` does not match `/^-?\d/` so it returns `0` -- identical behavior.

DBC output was verified identical before and after the change across all three generated files (Primary, Data, Charger).

## Convention

Optional fields should use `~` (YAML null) when not applicable, and should be filled out whenever the information is known.