### PR TITLE
Migrate Perl CANfigurator Parsers To Rust

### DIFF
--- a/Autogen/CAN/canfigurator/Cargo.toml
+++ b/Autogen/CAN/canfigurator/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "canfigurator"
+version = "0.1.0"
+edition = "2021"
+description = "GRCAN CANdo parser and code generator"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"

--- a/Autogen/CAN/canfigurator/src/main.rs
+++ b/Autogen/CAN/canfigurator/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("canfigurator: not yet implemented");
+}


### PR DESCRIPTION
## Summary

Replace all six Perl CANdo parsers with a single Rust binary (`canfigurator`) that reads `GRCAN.CANdo` once via `serde_yaml` and emits every generated artifact in one pass.

## Stack

This PR is stacked on:
- #550 — Normalize `bit_start` ranges to plain integers
- #551 — Remove thousands separators from numeric values
- #552 — Normalize dash placeholders to YAML null

Those PRs clean up CANdo format quirks so the Rust parser targets a consistent YAML schema.

## What This Replaces

| Perl Parser | Output |
|---|---|
| `BusParser.pl` (151 lines) | `GRCAN_BUS_ID.h` |
| `GRparser.pl` (224 lines) | `GRCAN_NODE_ID.h` |
| `MSGparser.pl` (129 lines) | `GRCAN_MSG_ID.h` |
| `CANparser.pl` (241 lines) | `GRCAN_CUSTOM_ID.h` |
| `STRUCTparser.pl` (370 lines) | `GRCAN_MSG_DATA.h` |
| `DBCparser.pl` (943 lines) | `GRCAN_{Bus}.dbc` × 3 |

**Total: 2,058 lines of Perl → single Rust binary**

## Approach

1. Parse `GRCAN.CANdo` with `serde_yaml` into typed Rust structs
2. Validate (duplicate detection, DLC ranges, routing consistency) — solves #375 and #373
3. Emit byte-identical output to current Perl parsers (verified by golden-file tests)
4. Run in parallel CI alongside Perl, then cut over

## Status

🚧 Draft — work in progress
